### PR TITLE
docs: typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ In your `nuxt.config.ts`, add an item in `icon.customCollections`:
 ```ts
 export default defineNuxtConfig({
   modules: [
-    'nuxt-icon'
+    '@nuxt/icon'
   ],
   icon: {
     customCollections: [


### PR DESCRIPTION
The package name `nuxt-icon` was incorrectly specified in the README. This PR corrects the name to `@nuxt/icon`