### PR TITLE
feat: allow local endpoint path to be overridden with `icon.localApiEndpoint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The icons will have the default size of `24px` and the `nuxt` icon will be avail
 <Icon name="nuxt" />
 ```
 
-By default, this module will create a server endpoint `/api/_nuxt_icon/:collection` to serve the icons from your local server bundle. When requesting an icon that does not exist in the local bundle, it will fallback to requesting [the official Iconify API](https://api.iconify.design). You can disable the fallback by setting `icon.fallbackToApi` to `false`, or set up [your own Iconify API](https://iconify.design/docs/api/hosting.html) and update `icon.iconifyApiEndpoint` to your own API endpoint.
+By default, this module will create a server endpoint `/api/_nuxt_icon/:collection` to serve the icons from your local server bundle (you can override the default path by setting `icon.localApiEndpoint` to your desired path). When requesting an icon that does not exist in the local bundle, it will fallback to requesting [the official Iconify API](https://api.iconify.design). You can disable the fallback by setting `icon.fallbackToApi` to `false`, or set up [your own Iconify API](https://iconify.design/docs/api/hosting.html) and update `icon.iconifyApiEndpoint` to your own API endpoint.
 
 ## Render Function
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -33,6 +33,7 @@ export default defineNuxtModule<ModuleOptions>({
     size: schema['size'].$default,
     aliases: schema['aliases'].$default,
     iconifyApiEndpoint: schema['iconifyApiEndpoint'].$default,
+    localApiEndpoint: schema['localApiEndpoint'].$default,
     fallbackToApi: schema['fallbackToApi'].$default,
     cssSelectorPrefix: schema['cssSelectorPrefix'].$default,
     cssWherePseudo: schema['cssWherePseudo'].$default,
@@ -53,7 +54,7 @@ export default defineNuxtModule<ModuleOptions>({
       filePath: resolver.resolve('./runtime/components/index'),
     })
     addServerHandler({
-      route: '/api/_nuxt_icon/:collection',
+      route: `${options.localApiEndpoint || '/api/_nuxt_icon'}/:collection`,
       handler: resolver.resolve('./runtime/server/api'),
     })
 

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -17,7 +17,7 @@ export default defineNuxtPlugin({
     if (options.provider === 'server') {
       const baseURL = config.app?.baseURL?.replace(/\/$/, '') ?? ''
 
-      resources.push(baseURL + '/api/_nuxt_icon')
+      resources.push(baseURL + (options.localApiEndpoint || '/api/_nuxt_icon'))
       if (options.fallbackToApi) {
         resources.push(options.iconifyApiEndpoint!)
       }

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -115,4 +115,13 @@ export interface NuxtIconRuntimeOptions {
    * @default true
    */
   fallbackToApi: boolean
+
+  /**
+   * Local API Endpoint Path
+   *
+   * Define a custom path for the local API endpoint.
+   *
+   * @default "/api/_nuxt_icon"
+   */
+  localApiEndpoint: string
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -125,4 +125,12 @@ export const schema = {
       tags: ['@studioIcon material-symbols:public'],
     },
   },
+  localApiEndpoint: {
+    $default: '/api/_nuxt_icon',
+    $schema: {
+      title: 'Local API Endpoint Path',
+      description: 'Define a custom path for the local API endpoint.',
+      tags: ['@studioIcon material-symbols:api'],
+    },
+  },
 } satisfies SchemaDefinition


### PR DESCRIPTION
Closes #185 

Adds a `localApiEndpoint` setting to the module options to allow the default server handler path to be overridden. This is useful in situations where the default `/api` prefix may conflict with existing path-forwarding rules.