### PR TITLE
fix: don't fail when scanning css rules from external stylesheets

### DIFF
--- a/src/runtime/components/css.ts
+++ b/src/runtime/components/css.ts
@@ -48,9 +48,14 @@ function getAllSelectors() {
     }
   }
 
-  for (let i = 0; i < document.styleSheets.length; i++) {
-    const rules = document.styleSheets[i].cssRules || document.styleSheets[i].rules
-    scanCssRules(rules)
+  for (const styleSheet of document.styleSheets) {
+    try {
+      const rules = styleSheet.cssRules || styleSheet.rules
+      scanCssRules(rules)
+    }
+    catch (error) {
+      // this typically means the stylesheet is from an inaccessible origin
+    }
   }
 
   return cssSelectors

--- a/src/runtime/components/css.ts
+++ b/src/runtime/components/css.ts
@@ -48,8 +48,10 @@ function getAllSelectors() {
     }
   }
 
-  for (let i = 0; i < document.styleSheets.length; i++) {
-    const rules = document.styleSheets[i].cssRules || document.styleSheets[i].rules
+  const localStyleSheets = Array.from(document.styleSheets).filter(styleSheet => !styleSheet.href || styleSheet.href.startsWith(window.location.origin))
+
+  for (let i = 0; i < localStyleSheets.length; i++) {
+    const rules = localStyleSheets[i].cssRules || localStyleSheets[i].rules
     scanCssRules(rules)
   }
 

--- a/src/runtime/components/css.ts
+++ b/src/runtime/components/css.ts
@@ -48,10 +48,8 @@ function getAllSelectors() {
     }
   }
 
-  const localStyleSheets = Array.from(document.styleSheets).filter(styleSheet => !styleSheet.href || styleSheet.href.startsWith(window.location.origin))
-
-  for (let i = 0; i < localStyleSheets.length; i++) {
-    const rules = localStyleSheets[i].cssRules || localStyleSheets[i].rules
+  for (let i = 0; i < document.styleSheets.length; i++) {
+    const rules = document.styleSheets[i].cssRules || document.styleSheets[i].rules
     scanCssRules(rules)
   }
 


### PR DESCRIPTION
Many modern browsers apply CORS rules to stylesheets. Accessing a stylesheet from a different origin may lead to DOM exceptions. 

It's not uncommon for some browser extensions to inject external stylesheets. Because of this, we should only attempt to pull stylesheets with a `href` of undefined (inline) or the same origin.

I believe this may resolve #189