### PR TITLE
feat: introduce remote collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ When the `name` matches a global registered component, it will be rendered as th
 
 Note that `MyComponent` needs to be inside `components/global/` folder (see [example](https://github.com/nuxt-modules/icon/blob/main/playground/components/global/NuxtLogo.vue)).
 
+You can also change the component name with:
+
+```ts
+export default defineNuxtConfig({
+  icon: {
+    componentName: 'NuxtIcon'
+  }
+})
+```
+
 ### Custom Local Collections
 
 You can use local SVG files to create a custom Iconify collection.
@@ -151,7 +161,7 @@ export default defineNuxtConfig({
   ],
   ssr: false,
   icon: {
-    provider: 'server', // <!-- this
+    provider: 'server', // <-- this
     customCollections: [
       {
         prefix: 'my-icon',

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ When using an icon from Iconify, an `<span>` or `<svg>` will be created based on
 <Icon name="uil:github" style="color: black" />
 ```
 
-### Iconify dataset
+### Iconify Dataset
 
 You can use any name from the https://icones.js.org collection:
 
@@ -93,7 +93,7 @@ npm i -D @iconify-json/collection-name
 
 For example, to use the `uil:github` icon, install it's collection with `@iconify-json/uil`. This way the icons can be served locally or from your serverless functions, which is faster and more reliable on both SSR and client-side.
 
-### Vue component
+### Vue Component
 
 When the `name` matches a global registered component, it will be rendered as that component (in this case `mode` will be ignored):
 
@@ -107,7 +107,7 @@ Note that `MyComponent` needs to be inside `components/global/` folder (see [exa
 
 You can use local SVG files to create a custom Iconify collection.
 
-For example, place your icons' SVG files under a folder on your choice, for example `./assets/my-icons`:
+For example, place your icons' SVG files under a folder of your choice, for example, `./assets/`my-icons`:
 
 ```bash
 assets/my-icons
@@ -142,13 +142,36 @@ Then you can use the icons like this:
 </template>
 ```
 
-## Configuration ⚙️
+Note that custom local collections require you to have a server to serve the API. When setting `ssr: false`, the provider will default to the Iconify API (which does not have your custom icons). If you want to build a SPA with server endpoints, you can explicitly set `provider: 'server'`:
+
+```ts
+export default defineNuxtConfig({
+  modules: [
+    '@nuxt/icon'
+  ],
+  ssr: false,
+  icon: {
+    provider: 'server', // <!-- this
+    customCollections: [
+      {
+        prefix: 'my-icon',
+        dir: './assets/my-icons'
+      },
+    ],
+  },
+})
+```
+
+### Icon Customization
 
 To update the default size (`1em`) of the `<Icon />`, create an `app.config.ts` with the `icon.size` property.
 
 Update the default class (`.icon`) of the `<Icon />` with the `icon.class` property, for a headless Icon, set `icon`.class: ''`.
 
 You can also define aliases to make swapping out icons easier by leveraging the `icon.aliases` property.
+
+> [!TIP]
+> Note it's `app.config.ts` and not `nuxt.config.ts` for runtime configs.
 
 ```ts
 // app.config.ts
@@ -172,7 +195,73 @@ The icons will have the default size of `24px` and the `nuxt` icon will be avail
 
 By default, this module will create a server endpoint `/api/_nuxt_icon/:collection` to serve the icons from your local server bundle (you can override the default path by setting `icon.localApiEndpoint` to your desired path). When requesting an icon that does not exist in the local bundle, it will fallback to requesting [the official Iconify API](https://api.iconify.design). You can disable the fallback by setting `icon.fallbackToApi` to `false`, or set up [your own Iconify API](https://iconify.design/docs/api/hosting.html) and update `icon.iconifyApiEndpoint` to your own API endpoint.
 
-## Render Function
+### Server Bundle
+
+Since `@nuxt/icon` v1.0, we have introduced the server bundle concept to serve the icons from Nuxt server endpoints. This keeps the client bundle lean and able to load icons on-demand, while having all the dynamic features to use icons that might now be known at build time.
+
+#### Server Bundle Mode: `local`
+
+This mode will bundle the icon collections you have installed locally (like `@iconify-json/*`), into your server bundle as dynamic chunks. The collection data will be loaded on-demand, only when your client request icons from that collection.
+
+#### Server Bundle Mode: `remote`
+
+Introduced in `@nuxt/icon` v1.2, you can now use the `remote` server bundle to serve the icons from a remote CDN.
+
+```ts
+export default defineNuxtConfig({
+  modules: [
+    '@nuxt/icon'
+  ],
+  icon: {
+    serverBundle: 'remote',
+  },
+})
+```
+
+Or you can specify the remote provider:
+
+```ts
+export default defineNuxtConfig({
+  modules: [
+    '@nuxt/icon'
+  ],
+  icon: {
+    serverBundle: {
+      remote: 'jsdelivr', // 'unpkg' or 'github-raw', or a custom function
+    }
+  },
+})
+```
+
+Which will make server requests to `https://cdn.jsdelivr.net/npm/@iconify-json/ph/icons.json` to fetch the icons at runtime, instead of bundling them with your server.
+
+Under the hood, instead of bundling `() => import('@iconify-json/ph/icons.json')` to your server bundle, it will now use something like `() => fetch('https://cdn.jsdelivr.net/npm/@iconify-json/ph/icons.json').then(res => res.json())`, where the collections are not inlined.
+
+This would be useful when server bundle size is a concern, like in serverless or worker environments.
+
+#### Server Bundle Mode: `auto`
+
+This is the default option, where the module will pick between `local` and `remote` based your deployment environment. `local` will be proffered unless you are deploying to a serverless or worker environment, like Vercel Edge or Cloudflare Workers.
+
+#### Completely Disable Server Bundle
+
+If you want to disable the server bundle completely, you can set `icon.serverBundle` to `false` and `provider` to `iconify`
+
+```ts
+export default defineNuxtConfig({
+  modules: [
+    '@nuxt/icon'
+  ],
+  icon: {
+    provider: 'iconify',
+    serverBundle: false,
+  },
+})
+```
+
+This will make requests to Iconify API every time the client requests an icon. We do not recommend doing so unless the other options are not feasible.
+
+### Render Function
 
 You can use the `Icon` component in a render function (useful if you create a functional component), for this you can import it from `#components`:
 

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -3,9 +3,11 @@ export default defineNuxtConfig({
     '../src/module',
     '@unocss/nuxt',
   ],
+
   extends: [
     './base',
   ],
+
   // ssr: false,
   icon: {
     customCollections: [
@@ -14,17 +16,24 @@ export default defineNuxtConfig({
         dir: './icons/custom1',
       },
     ],
+    serverBundle: 'remote',
   },
+
   nitro: {
     logLevel: 'verbose',
   },
+
   devtools: {
     enabled: true,
   },
+
   typescript: {
     includeWorkspace: true,
   },
+
   imports: {
     autoImport: false,
   },
+
+  compatibilityDate: '2024-07-18',
 })

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -104,6 +104,8 @@ export const schema = {
         '',
         '- `server` - Fetch icons with a server handler',
         '- `iconify` - Fetch icons with Iconify API, purely client-side',
+        '',
+        '`server` by default; `iconify` when `ssr: false`',
       ].join('\n'),
       enum: ['server', 'iconify'],
       tags: ['@studioIcon material-symbols:cloud'],

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,10 +20,14 @@ export interface ModuleOptions extends Partial<NuxtIconRuntimeOptions> {
   /**
    * Bundle icons for server to serve icons
    *
-   * - `auto`: Auto-discover all `@iconify-json/*` collections installed locally
+   * - `auto`: `local` when deploy to hosted platform, `remote` for edge workers
+   * - `local`: Auto-discover all `@iconify-json/*` collections installed locally
+   * - `remote`: Fetch collections from remote CDN. Same as `{ remote: true }`
    * - `{ collections: string[] }`: Specify collections to bundle
+   *
+   * @default 'auto'
    */
-  serverBundle?: 'auto' | false | ServerBundleOptions
+  serverBundle?: 'auto' | 'remote' | 'local' | false | ServerBundleOptions
 
   /**
    * Custom icon collections
@@ -40,15 +44,36 @@ export interface CustomCollection extends Pick<IconifyJSON, 'prefix' | 'width' |
   dir: string
 }
 
+export interface RemoteCollection {
+  prefix: string
+  fetchEndpoint: string
+}
+
+export type RemoteCollectionSource = 'github-raw' | 'jsdelivr' | 'unpkg' | ((name: string) => string)
+
 export interface ServerBundleOptions {
   /**
    * Iconify collection names to be bundled
    */
-  collections?: (string | CustomCollection | IconifyJSON)[]
+  collections?: (string | CustomCollection | IconifyJSON | RemoteCollection)[]
+  /**
+   * Whether to bundle remote collections
+   *
+   * When set to `true`, `jsdelivr` will be used as the default remote source
+   *
+   * @default false
+   */
+  remote?: boolean | RemoteCollectionSource
+  /**
+   * Whether to disable server bundle
+   */
+  disabled?: boolean
 }
 
 export interface ResolvedServerBundleOptions {
-  collections: (string | IconifyJSON)[]
+  disabled: boolean
+  remote: RemoteCollectionSource | false
+  collections: (string | IconifyJSON | RemoteCollection)[]
 }
 
 declare module '@nuxt/schema' {


### PR DESCRIPTION
- resolve #184 
- resolve #203 
- resolve #188

docs improvements:
- close #205 
- close #178
- close #200

This PR enables the ability to load icon collection data from CDN on the server side instead of loading it from the server bundle. It's called `RemoteCollection`. This would be useful when server bundle size is a concern, under environments like edge functions, or workers. Using a remote source slightly increases the load time of the collections on the first request. The introduction of an external runtime source slightly decreases the stability of the production app as the CDN might get down, and it's not version-controlled.

The default `auto` mode would now be the mode of choice based on the nitro deploy target.


