### PR TITLE
feat: introduce `clientBundle` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,10 +282,12 @@ export default defineNuxtConfig({
     '@nuxt/icon'
   ],
   icon: {
-    clientBundle: [
-      'uil:github',
-      'logos:vitejs'
-    ],
+    clientBundle: {
+      icons: [
+        'uil:github',
+        'logos:vitejs'
+      ],
+    },
   },
 })
 ```

--- a/README.md
+++ b/README.md
@@ -272,6 +272,26 @@ export default defineNuxtConfig({
 
 This will make requests to Iconify API every time the client requests an icon. We do not recommend doing so unless the other options are not feasible.
 
+### Client Bundle
+
+For icons that you know you are going to use frequently, you can bundle them with your client bundle to avoid network requests.
+
+```ts
+export default defineNuxtConfig({
+  modules: [
+    '@nuxt/icon'
+  ],
+  icon: {
+    clientBundle: [
+      'uil:github',
+      'logos:vitejs'
+    ],
+  },
+})
+```
+
+Currently, this is a manual config process, we are working on making it more automatic and easier to use.
+
 ### Render Function
 
 You can use the `Icon` component in a render function (useful if you create a functional component), for this you can import it from `#components`:

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -17,6 +17,12 @@ export default defineNuxtConfig({
       },
     ],
     serverBundle: 'remote',
+    clientBundle: {
+      icons: [
+        'logos:vitejs',
+        'ph:acorn-bold',
+      ],
+    },
   },
 
   nitro: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,7 +4,7 @@ import { defineNuxtModule, addPlugin, addServerHandler, hasNuxtModule, createRes
 import { addCustomTab } from '@nuxt/devtools-kit'
 import type { Nuxt } from '@nuxt/schema'
 import fg from 'fast-glob'
-import type { IconifyJSON } from '@iconify/types'
+import type { IconifyIcon, IconifyJSON } from '@iconify/types'
 import { parseSVGContent, convertParsedSVG } from '@iconify/utils/lib/svg/parse'
 import collectionNames from './collections'
 import { schema } from './schema'
@@ -32,6 +32,9 @@ export default defineNuxtModule<ModuleOptions>({
     componentName: 'Icon',
     serverBundle: 'auto',
     serverKnownCssClasses: [],
+    clientBundle: {
+      icons: [],
+    },
 
     // Runtime options
     provider: schema['provider'].$default,
@@ -116,7 +119,7 @@ export default defineNuxtModule<ModuleOptions>({
       options.customCollections,
     )
 
-    const template = addTemplate({
+    const templateServer = addTemplate({
       filename: 'nuxt-icon-server-bundle.mjs',
       write: true,
       async getContents() {
@@ -200,7 +203,54 @@ export default defineNuxtModule<ModuleOptions>({
       },
     })
     nuxt.options.nitro.alias ||= {}
-    nuxt.options.nitro.alias['#nuxt-icon-server-bundle'] = template.dst
+    nuxt.options.nitro.alias['#nuxt-icon-server-bundle'] = templateServer.dst
+
+    const iconifyCollectionMap = new Map<string, Promise<IconifyJSON | undefined>>()
+
+    // Client bundle
+    addTemplate({
+      filename: 'nuxt-icon-client-bundle.mjs',
+      write: true,
+      async getContents() {
+        const icons = options.clientBundle?.icons || []
+
+        if (!icons.length)
+          return 'export function init() {}'
+
+        const { getIconData } = await import('@iconify/utils')
+        const { loadCollectionFromFS } = await import('@iconify/utils/lib/loader/fs')
+
+        const lines: string[] = []
+
+        lines.push(
+          'import { addIcon } from "@iconify/vue"',
+          'let _initialized = false',
+          'export function init() {',
+          '  if (_initialized)',
+          '    return',
+          ...await Promise.all(icons.map(async (icon) => {
+            const [prefix, name] = icon.split(':')
+            if (!iconifyCollectionMap.has(prefix))
+              iconifyCollectionMap.set(prefix, loadCollectionFromFS(prefix))
+
+            let data: IconifyIcon | null = null
+            const collection = await iconifyCollectionMap.get(prefix)
+            if (collection)
+              data = getIconData(collection, name)
+
+            if (!data) {
+              logger.error(`Nuxt Icon could not fetch the icon data for \`${icon}\``)
+              return `  /* ${icon} failed to load */`
+            }
+            return `  addIcon('${icon}', ${JSON.stringify(data)})`
+          })),
+          '  _initialized = true',
+          '}',
+        )
+
+        return lines.join('\n')
+      },
+    })
 
     // Devtools
     addCustomTab({

--- a/src/runtime/components/shared.ts
+++ b/src/runtime/components/shared.ts
@@ -2,8 +2,10 @@ import { computed } from 'vue'
 import { loadIcons, getIcon as _getIcon } from '@iconify/vue'
 import type { NuxtIconRuntimeOptions } from '../../types'
 import { useAppConfig } from '#imports'
+import { init } from '#build/nuxt-icon-client-bundle'
 
 export async function loadIcon(name: string) {
+  init()
   await new Promise(resolve => loadIcons([name], () => resolve(true)))
     .catch(() => null)
   return _getIcon(name)

--- a/src/shim.d.ts
+++ b/src/shim.d.ts
@@ -3,3 +3,7 @@ declare module '#nuxt-icon-server-bundle' {
 
   export const collections: Record<string, () => Promise<IconifyCollection>>
 }
+
+declare module '#build/nuxt-icon-client-bundle' {
+  export function init(): void
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,11 @@ export interface ModuleOptions extends Partial<NuxtIconRuntimeOptions> {
   serverBundle?: 'auto' | 'remote' | 'local' | false | ServerBundleOptions
 
   /**
+   * Bundle icons into client-side.
+   */
+  clientBundle?: ClientBundleOptions
+
+  /**
    * Custom icon collections
    */
   customCollections?: CustomCollection[]
@@ -68,6 +73,13 @@ export interface ServerBundleOptions {
    * Whether to disable server bundle
    */
   disabled?: boolean
+}
+
+export interface ClientBundleOptions {
+  /**
+   * List of icons to be bundled, each icon should be in the formatted as `prefix:icon`
+   */
+  icons?: string[]
 }
 
 export interface ResolvedServerBundleOptions {


### PR DESCRIPTION
Partially improve https://github.com/nuxt/icon/issues/34#issuecomment-2241267837

This PR adds the capability of bundling icons to the client bundle. It's currently a manual configuration process, and we will explore the possibility of making it more automated.