### PR TITLE
fix: support nitro preset detection in zero config environments

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -65,7 +65,11 @@ export default defineNuxtModule<ModuleOptions>({
     if (serverBundle === 'auto') {
       serverBundle = nuxt.options.dev
         ? 'local'
-        : KEYWORDS_EDGE_TARGETS.some(word => typeof nuxt.options.nitro.preset === 'string' && nuxt.options.nitro.preset.includes(word))
+        : KEYWORDS_EDGE_TARGETS.some(word =>
+          (typeof nuxt.options.nitro.preset === 'string' && nuxt.options.nitro.preset.includes(word))
+          || process.env.NITRO_PRESET?.includes(word)
+          || process.env.SERVER_PRESET?.includes(word),
+        )
           ? 'remote'
           : 'local'
       logger.info(`Nuxt Icon server bundle mode is set to \`${serverBundle}\``)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #213 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

After some digging, I found out that `nuxt.options.nitro.preset` was `undefined` in my cloudflare build environment with zero-config support of nitro, but there's an environment variable `NITRO_PRESET:"cloudflare_pages"` we can use to detect the nitro preset just as nitro doing itself: [unjs/nitro: src/core/config/loader.ts](https://github.com/unjs/nitro/blob/62a74df2cac30fb6e73d4a83959e24daa3bcfa73/src/core/config/loader.ts#L62)