### PR TITLE
fix: insert styles before first style tag

### DIFF
--- a/src/runtime/components/css.ts
+++ b/src/runtime/components/css.ts
@@ -120,7 +120,8 @@ export const NuxtIconCss = /* @__PURE__ */ defineComponent({
         if (import.meta.dev) {
           style.dataset.nuxtIconDev = props.name
         }
-        document.head.prepend(style)
+        const firstStyle = document.head.querySelector('style, link[rel="stylesheet"]')
+        firstStyle ? document.head.insertBefore(style, firstStyle) : document.head.appendChild(style)
         selectors.add(selector.value)
       }
 

--- a/src/runtime/components/css.ts
+++ b/src/runtime/components/css.ts
@@ -121,7 +121,10 @@ export const NuxtIconCss = /* @__PURE__ */ defineComponent({
           style.dataset.nuxtIconDev = props.name
         }
         const firstStyle = document.head.querySelector('style, link[rel="stylesheet"]')
-        firstStyle ? document.head.insertBefore(style, firstStyle) : document.head.appendChild(style)
+        if (firstStyle)
+          document.head.insertBefore(style, firstStyle)
+        else
+          document.head.appendChild(style)
         selectors.add(selector.value)
       }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The styles of icons are prepended to head which is not very appropriate.

Screenshots:

<img width="542" alt="iShot_2024-07-26_19 06 43" src="https://github.com/user-attachments/assets/7a97c2f6-2fd4-48c2-b769-5bd26b79ab23">