### PR TITLE
fix(icon): use optional chaining to fix 'undefined' error in Histoire

### DIFF
--- a/src/runtime/components/css.ts
+++ b/src/runtime/components/css.ts
@@ -85,7 +85,7 @@ export const NuxtIconCss = /* @__PURE__ */ defineComponent({
       const icon = _getIcon(name)
       if (icon)
         return icon
-      const payload = nuxt.payload.data[name]
+      const payload = nuxt.payload?.data?.[name]
       if (payload) {
         addIcon(name, payload)
         return payload


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

When using the **Icon** component in Histoire, an error is thrown in css.js due to the lack of optional chaining in the _getIcon_ function.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
