### PR TITLE
Fix potential clash with /api

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -19,7 +19,7 @@ export default defineNuxtPlugin({
     if (options.provider === 'server') {
       const baseURL = config.app?.baseURL?.replace(/\/$/, '') ?? ''
 
-      resources.push(baseURL + (options.localApiEndpoint || '/api/_nuxt_icon'))
+      resources.push(baseURL + (options.localApiEndpoint || '/_nuxt_icon_api'))
       if (options.fallbackToApi) {
         resources.push(options.iconifyApiEndpoint!)
       }


### PR DESCRIPTION
The `/api/*` prefix is common enough that some people will want to use it for their own purposes, breaking NuxtIcon.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Here I use the following code in my `nuxt.config.ts` which allows SSR to communicate with my (non-Nuxt) backend :
```ts
  nitro: {
    routeRules: {
      '/api/**': { proxy: 'http://proxy:80/api/**' },
    },
  },
```
Which breaks recent versions of NuxtIcon because it (boldly) assumes `/api` is available. This PR fixes that.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
EDIT: I currently fix this by adding
```ts
  icon: {
    localApiEndpoint: '/_nuxt_icon_api/',
  },
```
to my `nuxt.config.ts` but I assume it shouldn't be necessary.