### PR TITLE
fix: add option customize to app.config and nuxt.config

### DIFF
--- a/src/runtime/components/index.ts
+++ b/src/runtime/components/index.ts
@@ -46,7 +46,7 @@ export default defineComponent({
         ? { fontSize: Number.isNaN(+size) ? size : size + 'px' }
         : null
     })
-    const customize = props.customize || optionCustomize
+    const customize = props.customize || options.customize || optionCustomize
 
     return () => h(
       component.value,


### PR DESCRIPTION
### 🔗 Linked issue

Complement to [#237]

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

currently it is possible to use option customize only in the Icon component and in nuxt.config.*

currently the priority is:

1. Component Icon
2. nuxt.config.*

with this new fix update the priority is:

1. Component Icon
2. app.config.*
3. nuxt.config.*
