### PR TITLE
fix: include ts and js files in scan

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -14,7 +14,7 @@ export function extraIconUsages(code: string, set: Set<string>, ignoreCollection
 
 export async function scanSourceFiles(nuxt: Nuxt, scanOptions: ClientBundleScanOptions | true, set: Set<string> = new Set()) {
   const {
-    globInclude = ['**/*.{vue,jsx,tsx,md,mdc,mdx}'],
+    globInclude = ['**/*.{vue,js,ts,jsx,tsx,md,mdc,mdx}'],
     globExclude = ['node_modules', 'dist', 'build', 'coverage', 'test', 'tests', '.*'],
     ignoreCollections = [],
   } = scanOptions === true ? {} : scanOptions


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Resolves #247 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This PR adds the missing `ts` and `js` files to the default scan `globInclude`.

The JSDOC says it does include them by default, but the actual implementation doesn't. So this PR adds them to match and also include TypeScript/JavaScript files into the scan.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
