### PR TITLE
fix: import server utils from `#imports`

### DIFF
--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -1,9 +1,9 @@
 import { basename } from 'pathe'
 import { getIcons } from '@iconify/utils'
 import { consola } from 'consola'
-import { useAppConfig, defineCachedEventHandler } from '#imports'
 import { createError, getQuery } from 'h3'
 import type { NuxtIconRuntimeOptions } from '../../schema-types'
+import { useAppConfig, defineCachedEventHandler } from '#imports'
 import { collections } from '#nuxt-icon-server-bundle'
 
 const warnOnceSet = /* @__PURE__ */ new Set<string>()

--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -65,7 +65,7 @@ export default defineCachedEventHandler(async (event: H3Event) => {
 }, {
   group: 'nuxt',
   name: 'icon',
-  getKey(event) {
+  getKey(event: H3Event) {
     const collection = event.context.params?.collection?.replace(/\.json$/, '') || 'unknown'
     const icons = String(getQuery(event).icons || '').split(',')
     return `${collection}_${icons.join('_')}`

--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -1,7 +1,7 @@
 import { basename } from 'pathe'
 import { getIcons } from '@iconify/utils'
 import { consola } from 'consola'
-import { useAppConfig, defineCachedEventHandler } from 'nitropack/runtime'
+import { useAppConfig, defineCachedEventHandler } from '#imports'
 import { createError, getQuery } from 'h3'
 import type { NuxtIconRuntimeOptions } from '../../schema-types'
 import { collections } from '#nuxt-icon-server-bundle'

--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -1,8 +1,9 @@
 import { basename } from 'pathe'
 import { getIcons } from '@iconify/utils'
 import { consola } from 'consola'
-import { createError, getQuery } from 'h3'
+import { createError, getQuery, type H3Event } from 'h3'
 import type { NuxtIconRuntimeOptions } from '../../schema-types'
+// @ts-expect-error tsconfig.server has the types
 import { useAppConfig, defineCachedEventHandler } from '#imports'
 import { collections } from '#nuxt-icon-server-bundle'
 
@@ -10,7 +11,7 @@ const warnOnceSet = /* @__PURE__ */ new Set<string>()
 
 const DEFAULT_ENDPOINT = 'https://api.iconify.design'
 
-export default defineCachedEventHandler(async (event) => {
+export default defineCachedEventHandler(async (event: H3Event) => {
   const url = event.node.req.url
   if (!url)
     return


### PR DESCRIPTION
Resolves https://github.com/nuxt/icon/issues/204 (tested against reproduction in https://github.com/nuxt/icon/issues/204#issuecomment-2325095934).

When having multiple versions of `nitropack` installed (reproduction above has one in the playground and one in top level) for some reason rollup keeps `nitropack/runtime` as an external although it shouldn't be. this needs more upstream investigation later)

Using `#imports` seems to fix the issue as it aliases to the explicit path.