### PR TITLE
feat: add console warning for icon load timeout

### DIFF
--- a/src/runtime/components/shared.ts
+++ b/src/runtime/components/shared.ts
@@ -1,5 +1,6 @@
 import { computed } from 'vue'
 import { loadIcons, getIcon as _getIcon } from '@iconify/vue'
+import { consola } from 'consola'
 import type { IconifyIcon } from '@iconify/types'
 import type { NuxtIconRuntimeOptions } from '../../types'
 import { useAppConfig } from '#imports'
@@ -19,7 +20,10 @@ export async function loadIcon(name: string, timeout: number): Promise<Required<
     .catch(() => null)
 
   if (timeout > 0)
-    await Promise.race([load, new Promise<void>(resolve => setTimeout(() => resolve(), timeout))])
+    await Promise.race([load, new Promise<void>(resolve => setTimeout(() => {
+      consola.warn(`[Icon] loading icon \`${name}\` timed out after ${timeout}ms`)
+      resolve()
+    }, timeout))])
   else
     await load
 


### PR DESCRIPTION
### 🔗 Linked issue

- n/a

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added a console.warn for when an icon-load fails due to timeout instead of failing silently. We had an issue where some flag icons wouldn't be loaded due to timeout and it took us quite some time to figure out why it was the case so I thought this could help more people.
