### PR TITLE
fix: `loadIcon` always console warn

### DIFF
--- a/src/runtime/components/shared.ts
+++ b/src/runtime/components/shared.ts
@@ -16,19 +16,25 @@ export async function loadIcon(name: string, timeout: number): Promise<Required<
   if (_icon)
     return _icon
 
+  let stopLoad: ReturnType<typeof loadIcons>
   let timeoutWarn: ReturnType<typeof setTimeout>
-  const load = new Promise<void>(resolve =>
-    loadIcons([name], () => {
+  const load = new Promise<void>((resolve) => {
+    stopLoad = loadIcons([name], () => {
       clearTimeout(timeoutWarn)
       resolve()
-    }),
+    })
+  },
   )
-    .catch(() => null)
+    .catch(() => {
+      stopLoad?.()
+      return null
+    })
 
   if (timeout > 0)
     await Promise.race([load, new Promise<void>((resolve) => {
       timeoutWarn = setTimeout(() => {
         consola.warn(`[Icon] loading icon \`${name}\` timed out after ${timeout}ms`)
+        stopLoad?.()
         resolve()
       }, timeout)
     })])

--- a/src/runtime/components/shared.ts
+++ b/src/runtime/components/shared.ts
@@ -18,8 +18,11 @@ export async function loadIcon(name: string, timeout: number): Promise<Required<
 
   let timeoutWarn: ReturnType<typeof setTimeout>
   const load = _loadIcon(name)
-    .then(() => clearTimeout(timeoutWarn))
-    .catch(() => null)
+    .catch(() => {
+      consola.warn(`[Icon] failed to load icon \`${name}\``)
+      return null
+    })
+    .finally(() => clearTimeout(timeoutWarn))
 
   if (timeout > 0)
     await Promise.race([load, new Promise<void>((resolve) => {

--- a/src/runtime/components/shared.ts
+++ b/src/runtime/components/shared.ts
@@ -16,14 +16,22 @@ export async function loadIcon(name: string, timeout: number): Promise<Required<
   if (_icon)
     return _icon
 
-  const load = new Promise<void>(resolve => loadIcons([name], () => resolve()))
+  let timeoutWarn: ReturnType<typeof setTimeout>
+  const load = new Promise<void>(resolve =>
+    loadIcons([name], () => {
+      clearTimeout(timeoutWarn)
+      resolve()
+    }),
+  )
     .catch(() => null)
 
   if (timeout > 0)
-    await Promise.race([load, new Promise<void>(resolve => setTimeout(() => {
-      consola.warn(`[Icon] loading icon \`${name}\` timed out after ${timeout}ms`)
-      resolve()
-    }, timeout))])
+    await Promise.race([load, new Promise<void>((resolve) => {
+      timeoutWarn = setTimeout(() => {
+        consola.warn(`[Icon] loading icon \`${name}\` timed out after ${timeout}ms`)
+        resolve()
+      }, timeout)
+    })])
   else
     await load
 

--- a/src/runtime/components/shared.ts
+++ b/src/runtime/components/shared.ts
@@ -1,5 +1,5 @@
 import { computed } from 'vue'
-import { loadIcons, getIcon as _getIcon } from '@iconify/vue'
+import { getIcon as _getIcon, loadIcon as _loadIcon } from '@iconify/vue'
 import { consola } from 'consola'
 import type { IconifyIcon } from '@iconify/types'
 import type { NuxtIconRuntimeOptions } from '../../types'
@@ -16,25 +16,15 @@ export async function loadIcon(name: string, timeout: number): Promise<Required<
   if (_icon)
     return _icon
 
-  let stopLoad: ReturnType<typeof loadIcons>
   let timeoutWarn: ReturnType<typeof setTimeout>
-  const load = new Promise<void>((resolve) => {
-    stopLoad = loadIcons([name], () => {
-      clearTimeout(timeoutWarn)
-      resolve()
-    })
-  },
-  )
-    .catch(() => {
-      stopLoad?.()
-      return null
-    })
+  const load = _loadIcon(name)
+    .then(() => clearTimeout(timeoutWarn))
+    .catch(() => null)
 
   if (timeout > 0)
     await Promise.race([load, new Promise<void>((resolve) => {
       timeoutWarn = setTimeout(() => {
         consola.warn(`[Icon] loading icon \`${name}\` timed out after ${timeout}ms`)
-        stopLoad?.()
         resolve()
       }, timeout)
     })])


### PR DESCRIPTION
### 🔗 Linked issue

resolves #271

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR addresses an issue where the console warning `[Icon] loading icon <name> timed out after <timeout>ms` would be shown, even though the icons were loaded successfully. This happened due to incorrect handling of icon loading timeouts.

#### Changes introduced:
1. **Improved error handling**: Now, if `_loadIcon` fails to load the icon, a specific warning message `[Icon] failed to load icon <name>` will be logged, giving more visibility into failed loads.
2. **Timeout handling fix**: The timeout warning `[Icon] loading icon <name> timed out after <timeout>ms` will now only appear if the icon fails to load within the specified timeout period.
3. **Cleanup with `finally`**: Ensures that the timeout warning is cleared properly whether the icon is loaded successfully or fails.

### 📝 Additional context

If you only want the bug fix (`c072229e163fcf738c22fe1bfea9178434651419`), you can pick only that specific commit