### PR TITLE
fix: improve deno compatibility by using node specifier in server bundle

### DIFF
--- a/src/bundle-server.ts
+++ b/src/bundle-server.ts
@@ -68,7 +68,7 @@ export function registerServerBundle(
         ...(isBundling
           ? []
           : [
-              `import { createRequire } from 'module'`,
+              `import { createRequire } from 'node:module'`,
               `const require = createRequire(import.meta.url)`,
             ]
         ),


### PR DESCRIPTION
### 🔗 Linked issue
resolves #276 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
People using Deno 2.0 will get an error when running the dev server due to the server bundle not using the `node:` prefix for the `module` core module.

The rest of the codebase uses `node:` prefixes so this would also help with consistency.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
