### PR TITLE
feat: Propagate SVG changes in customCollections to client and server bundles without nuxt server restart

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -32,6 +32,7 @@ export default defineNuxtConfig({
         'logos:vitejs',
         'ph:acorn-bold',
       ],
+      includeCustomCollections: true,
       scan: true,
     },
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -76,7 +76,7 @@ export default defineNuxtModule<ModuleOptions>({
       handler: resolver.resolve('./runtime/server/api'),
     })
 
-    await addCustomCollectionsWatcher(options, nuxt, ctx)
+    await setupCustomCollectionsWatcher(options, nuxt, ctx)
 
     // Merge options to app.config
     const runtimeOptions = Object.fromEntries(
@@ -167,11 +167,13 @@ export default defineNuxtModule<ModuleOptions>({
   },
 })
 
-async function addCustomCollectionsWatcher(options: ModuleOptions, nuxt: Nuxt, ctx: NuxtIconModuleContext) {
-  if (!options.customCollections?.length) return
+async function setupCustomCollectionsWatcher(options: ModuleOptions, nuxt: Nuxt, ctx: NuxtIconModuleContext) {
+  if (!options.customCollections?.length)
+    return
 
   let viteDevServer: ViteDevServer
   const collectionDirs = await Promise.all(options.customCollections.map(x => nuxtResolvePath(x.dir)))
+
   if (options.clientBundle?.includeCustomCollections) {
     addVitePlugin({
       name: 'nuxt-icon/client-bundle-updater',


### PR DESCRIPTION
### 🔗 Linked issue

resolves #281

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

watches changes in files from customCollections directories, and on any change triggers:
- rebuild of client icons bundle 
- rebuild of server icons bundle
- invalidates client bundle in vite dev server 

Potential future improvements (let me know if you're interested, i can create further PR):
- debounce bundles rebuilding in case of rapid file changes
- HMR - probably needs custom message from HMR server to Icon.vue