### PR TITLE
fix(components): fixed duplicate icon class names

### DIFF
--- a/src/runtime/components/css.ts
+++ b/src/runtime/components/css.ts
@@ -194,6 +194,6 @@ export const NuxtIconCss = /* @__PURE__ */ defineComponent({
       }
     }
 
-    return () => h('span', { class: ['iconify', cssClass.value, options.class] })
+    return () => h('span', { class: ['iconify', cssClass.value] })
   },
 })

--- a/src/runtime/components/svg.ts
+++ b/src/runtime/components/svg.ts
@@ -49,7 +49,6 @@ export const NuxtIconSvg = /* @__PURE__ */ defineComponent({
     return () => h(Iconify, {
       icon: name.value,
       ssr: true,
-      class: options.class,
       // Iconify uses `customise`, where we expose `customize` for consistency
       customise: props.customize,
     }, slots)


### PR DESCRIPTION
Configuring classes in app.config.ts may result in two duplicate class names for the component

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Removed the passthrough classes from CSS components and SVG components, only using classes in the icon component, resolving the issue of duplication caused by double-layer passthrough in Vue components.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
