### PR TITLE
fix: fallback to `customize` function from app.config

### DIFF
--- a/src/runtime/components/css.ts
+++ b/src/runtime/components/css.ts
@@ -104,7 +104,7 @@ export const NuxtIconCss = /* @__PURE__ */ defineComponent({
       const css = getIconCSS(icon, {
         iconSelector,
         format: 'compressed',
-        customise: props.customize ?? options.customize
+        customise: props.customize ?? options.customize,
       })
       if (options.cssLayer && withLayer) {
         return `@layer ${options.cssLayer} { ${css} }`

--- a/src/runtime/components/css.ts
+++ b/src/runtime/components/css.ts
@@ -104,7 +104,7 @@ export const NuxtIconCss = /* @__PURE__ */ defineComponent({
       const css = getIconCSS(icon, {
         iconSelector,
         format: 'compressed',
-        customise: props.customize,
+        customise: props.customize ?? options.customize
       })
       if (options.cssLayer && withLayer) {
         return `@layer ${options.cssLayer} { ${css} }`

--- a/src/runtime/components/svg.ts
+++ b/src/runtime/components/svg.ts
@@ -50,7 +50,7 @@ export const NuxtIconSvg = /* @__PURE__ */ defineComponent({
       icon: name.value,
       ssr: true,
       // Iconify uses `customise`, where we expose `customize` for consistency
-      customise: props.customize,
+      customise: props.customize ?? options.customize,
     }, slots)
   },
 })


### PR DESCRIPTION
### 🔗 Linked Issue

N/A

### ❓ Type of Change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This patch ensures the `customize` option from `app.config` is utilized as a fallback when the `customize` prop is not explicitly provided, further allowing for a global `customize` option.