### PR TITLE
docs: cssLayer for TailwindCSS v4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ When using an icon from Iconify, an `<span>` or `<svg>` will be created based on
 
 **TailwindCSS v4**:
 
-When using TailwindCSS v4 with the `css` mode, you should configure the `cssLayer` in Nuxt's Application configuration file:
+When using TailwindCSS v4 with the `css` mode, you should configure the `cssLayer` in Nuxt's app config:
 
 ```ts
 // ~/app.config.ts
@@ -247,7 +247,7 @@ export default defineAppConfig({
     aliases: {
       'nuxt': 'logos:nuxt-icon',
     },
-    cssLayer: 'base' // required for TailwindCSS v4.
+    cssLayer: 'base' // set the css layer to inject to
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ When using an icon from Iconify, an `<span>` or `<svg>` will be created based on
 <Icon name="uil:github" style="color: black" />
 ```
 
+**TailwindCSS v4**:
+
+When using TailwindCSS v4 with the `css` mode, you should configure the `cssLayer` in Nuxt's Application configuration file:
+
+```ts
+// ~/app.config.ts
+export default defineAppConfig({
+  icon: {
+    mode: 'css',
+    cssLayer: 'base'
+  }
+})
+```
+
 ### Iconify Dataset
 
 You can use any name from the https://icones.js.org collection:
@@ -232,7 +246,8 @@ export default defineAppConfig({
     mode: 'css', // default <Icon> mode applied
     aliases: {
       'nuxt': 'logos:nuxt-icon',
-    }
+    },
+    cssLayer: 'base' // required for TailwindCSS v4.
   }
 })
 ```


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Based from https://github.com/tailwindlabs/tailwindcss/issues/17202, all styles should be inside the base layer otherwise the higher specificity prevents any customisation with CSS. After digging around the codebase, I saw that there is already a provision for this [here](https://github.com/nuxt/icon/blob/main/src/runtime/components/css.ts#L110) that wasn't documented in the README.
