### PR TITLE
fix: apply hydration mismatch bug fix to SVG icons

### DIFF
--- a/src/runtime/components/svg.ts
+++ b/src/runtime/components/svg.ts
@@ -30,7 +30,7 @@ export const NuxtIconSvg = /* @__PURE__ */ defineComponent({
       // @See https://github.com/nuxt/icon/issues/356
       onServerPrefetch(async () => {
         if (import.meta.server) {
-          useAsyncData(
+          await useAsyncData(
             storeKey,
             () => loadIcon(name.value, options.fetchTimeout),
             { deep: false },

--- a/src/runtime/components/svg.ts
+++ b/src/runtime/components/svg.ts
@@ -32,7 +32,7 @@ export const NuxtIconSvg = /* @__PURE__ */ defineComponent({
         if (import.meta.server) {
           await useAsyncData(
             storeKey,
-            async ()  => await loadIcon(name.value, options.fetchTimeout),
+            async () => await loadIcon(name.value, options.fetchTimeout),
             { deep: false },
           )
         }

--- a/src/runtime/components/svg.ts
+++ b/src/runtime/components/svg.ts
@@ -3,7 +3,7 @@ import { h } from 'vue'
 import type { PropType } from 'vue'
 import type { NuxtIconRuntimeOptions, IconifyIconCustomizeCallback } from '../../types'
 import { initClientBundle, loadIcon, useResolvedName } from './shared'
-import { useAsyncData, useNuxtApp, defineComponent, useAppConfig } from '#imports'
+import { useAsyncData, useNuxtApp, defineComponent, useAppConfig, onServerPrefetch } from '#imports'
 
 export const NuxtIconSvg = /* @__PURE__ */ defineComponent({
   name: 'NuxtIconSvg',
@@ -26,13 +26,17 @@ export const NuxtIconSvg = /* @__PURE__ */ defineComponent({
 
     if (name.value) {
       // On server side, we fetch the icon data and store it in the payload
-      if (import.meta.server) {
-        useAsyncData(
-          storeKey,
-          () => loadIcon(name.value, options.fetchTimeout),
-          { deep: false },
-        )
-      }
+      // Apply server prefetch function used for CSS icons. 
+      // @See https://github.com/nuxt/icon/issues/356
+      onServerPrefetch(async () => {
+        if (import.meta.server) {
+          useAsyncData(
+            storeKey,
+            () => loadIcon(name.value, options.fetchTimeout),
+            { deep: false },
+          )
+        }
+      })
 
       // On client side, we feed Iconify we the data we have from server side to avoid hydration mismatch
       if (import.meta.client) {

--- a/src/runtime/components/svg.ts
+++ b/src/runtime/components/svg.ts
@@ -26,7 +26,7 @@ export const NuxtIconSvg = /* @__PURE__ */ defineComponent({
 
     if (name.value) {
       // On server side, we fetch the icon data and store it in the payload
-      // Apply server prefetch function used for CSS icons. 
+      // Apply server prefetch function used for CSS icons.
       // @See https://github.com/nuxt/icon/issues/356
       onServerPrefetch(async () => {
         if (import.meta.server) {

--- a/src/runtime/components/svg.ts
+++ b/src/runtime/components/svg.ts
@@ -32,7 +32,7 @@ export const NuxtIconSvg = /* @__PURE__ */ defineComponent({
         if (import.meta.server) {
           await useAsyncData(
             storeKey,
-            () => loadIcon(name.value, options.fetchTimeout),
+            async ()  => await loadIcon(name.value, options.fetchTimeout),
             { deep: false },
           )
         }


### PR DESCRIPTION
### 🔗 Linked issue

resolves [#356](https://github.com/nuxt/icon/issues/356)

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I ran into the issue described [here](https://github.com/nuxt/icon/issues/310) (hydration mismatch warnings caused by @nuxt/icon) and I see a [fix](https://github.com/nuxt/icon/commit/f5e74f592a10da1e0e56dfad137e19baf70f39b8) was developed, but it did not resolve the issue with my app -- the fix appears to have only applied to CSS icons, while I use SVG.

After applying what appeared to be the most simple code change in replicating the CSS-focused fix above to SVG icons, the hydration mismatch issue appears to be resolved. 

Original issue reproduction (my first usage of Stackblitz):
https://stackblitz.com/edit/vitejs-vite-a8edpmzn

Issue resolved when using my fork with the fixes in this PR:
https://stackblitz.com/edit/vitejs-vite-oxw3dzpq

I was able to load the @nuxt/icon playground in addition to using my own app things seem to be working OK, but I'm not familiar enough with the intricacies of this project to be absolutely confident that this is the only code change required. 
