### PR TITLE
Update README.md to include a Nuxt 4 app dir note

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ export default defineNuxtConfig({
   },
 })
 ```
+> [!NOTE]
+> If you are running on Nuxt4 with the new `app` directory, make sure your directory is `'./app/assets/my-icons'` instead of `'./assets/my-icons'`.
 
 Then you can use the icons like this:
 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,9 @@ export default defineNuxtConfig({
   },
 })
 ```
+
 > [!NOTE]
-> If you are running on Nuxt4 with the new `app` directory, make sure your directory is `'./app/assets/my-icons'` instead of `'./assets/my-icons'`.
+> If you are running on Nuxt 4 with the new `app` directory, the assets directory is `'./app/assets/*'` instead of `'./assets/*'`.
 
 Then you can use the icons like this:
 


### PR DESCRIPTION

### 🔗 Linked issue

Resolves https://github.com/nuxt/icon/issues/400

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I noticed that there wasn't any documentation on configuring Nuxt Icons with the new Nuxt 4 app directory. It took me a while to debug until I realized the issue.

This could be a temporary fix, but the nuxt-icon module can detect the folder structure to determine where the assets directory really is.
