### PR TITLE
Highlight the need to set provider: server when using nuxt generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ export default defineNuxtConfig({
 })
 ```
 
-Note that custom local collections require you to have a server to serve the API. When setting `ssr: false`, the provider will default to the Iconify API (which does not have your custom icons). If you want to build a SPA with server endpoints, you can explicitly set `provider: 'server'`:
+Note that custom local collections require you to have a server to serve the API. When setting `ssr: false`, or when generating a static app using `nuxt generate` (which is equivalent to ssr: false), the provider will default to the Iconify API (which does not have your custom icons). If you want to build a SPA with server endpoints, you can explicitly set `provider: 'server'`:
 
 ```ts
 export default defineNuxtConfig({


### PR DESCRIPTION
### 🔗 Linked issue

[#403 - Highlight the need to use provider: 'server' when using 'nuxt generate'](https://github.com/nuxt/icon/issues/403)

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Nuxt Icon module supports local bundling out-of-the-box, and the client bundle is enabled by default. However, when running nuxt generate, the icon bundles are still being loaded from the Iconify CDN instead of using the local bundles.

The documentation already mentions that when ssr: false, you need to set provider: "server" if you want to use local collections.

Since nuxt generate is equivalent to ssr: false (as it's generating a static site), it would be helpful to mention this in the documentation explicitly.

This clarification would benefit both developers and tools like LLMs, helping to make the integration smoother.
