### PR TITLE
fix: prefer `nitro.static` over `_generate`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -58,7 +58,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Use `server` provider when SSR is disabled or generate mode
     if (!options.provider) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      options.provider = (!nuxt.options.ssr || (nuxt.options.nitro.static || (nuxt.options as any)._generate))
+      options.provider = (!nuxt.options.ssr || nuxt.options.nitro.static || (nuxt.options as any)._generate)
         ? 'iconify'
         : 'server'
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -57,7 +57,8 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Use `server` provider when SSR is disabled or generate mode
     if (!options.provider) {
-      options.provider = (!nuxt.options.ssr || nuxt.options._generate)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      options.provider = (!nuxt.options.ssr || (nuxt.options.nitro.static || (nuxt.options as any)._generate))
         ? 'iconify'
         : 'server'
     }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


Since nuxi v3.8, we've supported setting `nuxt.options.nitro.static` instead of `nuxt.options._generate` (which is an internal flag) - see https://github.com/nuxt/nuxt/pull/21860.

Now, in preparation for Nuxt v4, we've removed the types for `_generate` (see https://github.com/nuxt/nuxt/pull/32355). This PR adds support for new version in backwards compatible way (ignoring type issues) - I'd suggest you remove support in a future major.