### PR TITLE
fix: drop use of private `_build` flag

### DIFF
--- a/src/bundle-client.ts
+++ b/src/bundle-client.ts
@@ -26,7 +26,7 @@ export function registerClientBundle(
 
       if (failed.length) {
         const msg = `Nuxt Icon could not fetch the icon data for client bundle:\n${failed.map(f => ' - ' + f).join('\n')}`
-        if (ctx.nuxt.options._build)
+        if (!ctx.nuxt.options.dev)
           throw new Error(msg)
         else
           logger.warn(msg)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We dropped this flag for Nuxt v4. As long as the intent here wasn't to check vs. static generation, this should be a safe substitution.

https://github.com/nuxt/ecosystem-ci/actions/runs/15928068917/job/44930076624