### PR TITLE
Remove devDependencies on manual install

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ That's it, you can now use the `<Icon />` in your components!
 You can install the module manually with:
 
 ```bash
-npm i -D @nuxt/icon
+npm i @nuxt/icon
 ```
 
 Update your `nuxt.config.ts`


### PR DESCRIPTION
aligning install with the `npx nuxi` command

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

`npx nuxi module add icon` command doesn't add the package as `devDependencies`. This PR updates the manual installation to align the installation on both methods.