### PR TITLE
fix: ensure deterministic icon sort order in client bundle

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -253,6 +253,11 @@ export class NuxtIconModuleContext {
         }))
     }
 
+    for (const collection of collections.values()) {
+      const sortedEntries = Object.entries(collection.icons).sort(([nameA], [nameB]) => nameA.localeCompare(nameB))
+      collection.icons = Object.fromEntries(sortedEntries)
+    }
+
     return {
       collections: [...collections.values()],
       count,


### PR DESCRIPTION
Sort icons alphabetically within each collection to ensure idempotent output regardless of discovery order

### 🔗 Linked issue

Resolves #445

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I'd like to cache the client bundle but currently it easily changes between runs when using a config like:

```ts
clientBundle: {
    includeCustomCollections: true,
    scan: true,
}
```

It's because the order of the keys in each collection's "icons" object is not consistent.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
