### PR TITLE
chore: include `.nuxt` types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
   "exclude": [
     "playground",
     "dist",
-    "node_modules",
-    ".nuxt"
+    "node_modules"
   ]
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

excluding `.nuxt` prevents generated nuxt types from being applied (e.g. anything in `.nuxt/nuxt.d.ts`, including type augmentations for nuxt options.

not sure what the reason was but if there was a bug you were encountering that [led you to exclude it](https://github.com/nuxt/icon/commit/4fbed5cb68c18e3d353743603ee40b5e5bf3cf11/tsconfig.json), please do let me know 🙏 