### PR TITLE
docs(readme): clarify prefetch via client bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,65 @@ This will make requests to Iconify API every time the client requests an icon. W
 
 For icons that you know you are going to use frequently, you can bundle them with your client bundle to avoid network requests.
 
+#### Prefetch (Preload) Icons
+
+If you want icons to be available on first render, use the client bundle as the prefetch mechanism:
+
+```ts
+export default defineNuxtConfig({
+  modules: [
+    '@nuxt/icon',
+  ],
+  icon: {
+    clientBundle: {
+      // Explicitly pre-bundle known icons
+      icons: ['uil:github', 'heroicons:home'],
+      // Keep disabled if you only want explicit entries
+      scan: false,
+    },
+  },
+})
+```
+
+You can also enable static scanning to pre-bundle icons referenced literally in your source files:
+
+```ts
+export default defineNuxtConfig({
+  modules: [
+    '@nuxt/icon',
+  ],
+  icon: {
+    clientBundle: {
+      // Automatically includes statically-detected icon usages
+      scan: true,
+      // Keep explicit entries for dynamic icon names
+      icons: ['uil:github'],
+    },
+  },
+})
+```
+
+If you want to disable runtime icon fetching entirely, combine client bundle with `provider: 'none'`:
+
+```ts
+export default defineNuxtConfig({
+  modules: [
+    '@nuxt/icon',
+  ],
+  icon: {
+    provider: 'none',
+    clientBundle: {
+      scan: true,
+      icons: ['uil:github'],
+    },
+  },
+})
+```
+
+> [!TIP]
+> Static scanning relies on literal values. Dynamically generated icon names are not reliably detected, so add them explicitly in `clientBundle.icons`.
+> This is also useful for component-test setups documented in [Rendering Icons in Component Tests](#rendering-icons-in-component-tests).
+
 ```ts
 export default defineNuxtConfig({
   modules: [

--- a/README.md
+++ b/README.md
@@ -484,26 +484,12 @@ export default defineNuxtConfig({
 })
 ```
 
-If you want to disable runtime icon fetching entirely, combine client bundle with `provider: 'none'`:
-
-```ts
-export default defineNuxtConfig({
-  modules: [
-    '@nuxt/icon',
-  ],
-  icon: {
-    provider: 'none',
-    clientBundle: {
-      scan: true,
-      icons: ['uil:github'],
-    },
-  },
-})
-```
+If you want to disable runtime icon fetching entirely, see [Custom Local Collections](#custom-local-collections) for the `provider: 'none'` + client bundle pattern.
 
 > [!TIP]
-> Static scanning relies on literal values. Dynamically generated icon names are not reliably detected, so add them explicitly in `clientBundle.icons`.
-> This is also useful for component-test setups documented in [Rendering Icons in Component Tests](#rendering-icons-in-component-tests).
+> Static scanning only detects literal icon names. See [Scan Components](#scan-components) for details and examples, and [Rendering Icons in Component Tests](#rendering-icons-in-component-tests) for test-environment setup.
+
+#### Available Options
 
 ```ts
 export default defineNuxtConfig({

--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ export default defineNuxtConfig({
 })
 ```
 
+#### Disabling Runtime Fetching
+
 Or if you want to disable the dynamic icon fetching completely and only use icons from the [client bundle](#client-bundle), you can set `provider: 'none'`:
 
 ```ts
@@ -484,7 +486,7 @@ export default defineNuxtConfig({
 })
 ```
 
-If you want to disable runtime icon fetching entirely, see [Custom Local Collections](#custom-local-collections) for the `provider: 'none'` + client bundle pattern.
+If you want to disable runtime icon fetching entirely, see [Disabling Runtime Fetching](#disabling-runtime-fetching) for the `provider: 'none'` + client bundle pattern.
 
 > [!TIP]
 > Static scanning only detects literal icon names. See [Scan Components](#scan-components) for details and examples, and [Rendering Icons in Component Tests](#rendering-icons-in-component-tests) for test-environment setup.


### PR DESCRIPTION
Fixes #99

Clarifies in `README.md` how to prefetch icons with `clientBundle`:
- explicit icons via `clientBundle.icons`
- static extraction via `clientBundle.scan`
- optional `provider: 'none'` for no runtime fetching
