### PR TITLE
fix: detect package manager for collection install suggestion

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { resolve as pathResolve } from 'node:path'
 import { defineNuxtModule, addPlugin, addServerHandler, hasNuxtModule, createResolver, addComponent, logger, updateTemplates, resolvePath as nuxtResolvePath, addVitePlugin } from '@nuxt/kit'
 import { addCustomTab } from '@nuxt/devtools-kit'
 import { resolvePath } from 'mlly'
@@ -86,6 +88,10 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     await setupCustomCollectionsWatcher(options, nuxt, ctx)
+
+    // Detect package manager for install suggestions
+    const pmInstallCommand = detectInstallCommand(nuxt.options.rootDir)
+    nuxt.options.runtimeConfig.public.nuxtIconInstallCommand = pmInstallCommand
 
     // Merge options to app.config
     const runtimeOptions = Object.fromEntries(
@@ -223,4 +229,17 @@ async function setupCustomCollectionsWatcher(options: ModuleOptions, nuxt: Nuxt,
       }
     }
   })
+}
+
+function detectInstallCommand(rootDir: string): string {
+  if (existsSync(pathResolve(rootDir, 'pnpm-lock.yaml'))) {
+    return 'pnpm add -D'
+  }
+  if (existsSync(pathResolve(rootDir, 'yarn.lock'))) {
+    return 'yarn add -D'
+  }
+  if (existsSync(pathResolve(rootDir, 'bun.lockb')) || existsSync(pathResolve(rootDir, 'bun.lock'))) {
+    return 'bun add -D'
+  }
+  return 'npm i -D'
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -231,6 +231,13 @@ async function setupCustomCollectionsWatcher(options: ModuleOptions, nuxt: Nuxt,
   })
 }
 
+/**
+ * Detects the project's package manager by checking for lockfiles
+ * and returns the corresponding install command.
+ *
+ * @param rootDir - The root directory of the Nuxt project
+ * @returns The install command string (e.g. 'pnpm add -D', 'yarn add -D')
+ */
 function detectInstallCommand(rootDir: string): string {
   if (existsSync(pathResolve(rootDir, 'pnpm-lock.yaml'))) {
     return 'pnpm add -D'

--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -5,7 +5,7 @@ import { createError, getQuery, type H3Event } from 'h3'
 import { consola } from 'consola'
 import type { NuxtIconRuntimeOptions } from '../../schema-types'
 // @ts-expect-error tsconfig.server has the types
-import { useAppConfig, getRequestURL, defineCachedEventHandler } from '#imports'
+import { useAppConfig, useRuntimeConfig, getRequestURL, defineCachedEventHandler } from '#imports'
 import { collections } from '#nuxt-icon-server-bundle'
 
 const warnOnceSet = /* @__PURE__ */ new Set<string>()
@@ -39,9 +39,10 @@ export default defineCachedEventHandler(async (event: H3Event) => {
   else if (import.meta.dev) {
     // Warn only once per collection, and only with the default endpoint
     if (collectionName && !warnOnceSet.has(collectionName) && apiEndPoint === DEFAULT_ENDPOINT) {
+      const installCmd = useRuntimeConfig().public?.nuxtIconInstallCommand || 'npm i -D'
       consola.warn([
         `[Icon] Collection \`${collectionName}\` is not found locally`,
-        `We suggest to install it via \`npm i -D @iconify-json/${collectionName}\` to provide the best end-user experience.`,
+        `We suggest to install it via \`${installCmd} @iconify-json/${collectionName}\` to provide the best end-user experience.`,
       ].join('\n'))
       warnOnceSet.add(collectionName)
     }


### PR DESCRIPTION
## Summary

Fixes #473

The dev warning for missing icon collections always suggests `npm i -D @iconify-json/<collection>`, regardless of the project's actual package manager.

## Fix

Detects the package manager at build time by checking lockfiles in the project root, then passes the install command to the server runtime via `runtimeConfig`.

| Lockfile | Suggested command |
|----------|------------------|
| `pnpm-lock.yaml` | `pnpm add -D` |
| `yarn.lock` | `yarn add -D` |
| `bun.lockb` / `bun.lock` | `bun add -D` |
| fallback | `npm i -D` |

### Before
```
[Icon] Collection `mdi` is not found locally
We suggest to install it via `npm i -D @iconify-json/mdi`
```

### After (in a pnpm project)
```
[Icon] Collection `mdi` is not found locally
We suggest to install it via `pnpm add -D @iconify-json/mdi`
```