### PR TITLE
fix: detect installed collections from Nuxt rootDir/workspaceDir

### DIFF
--- a/src/bundle-server.ts
+++ b/src/bundle-server.ts
@@ -48,7 +48,7 @@ export function registerServerBundle(
             return `  '${collection}': createRemoteCollection(${JSON.stringify(getRemoteEndpoint(collection))}),`
           }
 
-          const path = getCollectionPath(collection)
+          const path = getCollectionPath(collection, nuxt)
 
           // When in dev mode, we avoid bundling the icons to improve performance
           // Get rid of the require() when ESM JSON modules are widely supported

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -9,7 +9,15 @@ import { isPackageExists } from 'local-pkg'
 import { collectionNames } from './collection-names'
 import type { CustomCollection, ServerBundleOptions, RemoteCollection } from './types'
 
-export const isFullCollectionExists = isPackageExists('@iconify/json')
+function getResolvePaths(nuxt: Nuxt): string[] {
+  return Array.from(new Set(
+    [nuxt.options.rootDir, nuxt.options.workspaceDir].filter(Boolean),
+  ))
+}
+
+export function hasFullCollection(nuxt: Nuxt): boolean {
+  return isPackageExists('@iconify/json', { paths: getResolvePaths(nuxt) })
+}
 
 export async function resolveCollection(
   nuxt: Nuxt,
@@ -24,8 +32,8 @@ export async function resolveCollection(
   return collection
 }
 
-export function getCollectionPath(collection: string) {
-  return isFullCollectionExists
+export function getCollectionPath(collection: string, nuxt: Nuxt) {
+  return hasFullCollection(nuxt)
     ? `@iconify/json/json/${collection}.json`
     : `@iconify-json/${collection}/icons.json`
 }
@@ -117,16 +125,18 @@ async function parseCustomCollection(
   return result
 }
 
-export async function discoverInstalledCollections(): Promise<ServerBundleOptions['collections']> {
-  const collections = isFullCollectionExists
+export async function discoverInstalledCollections(nuxt: Nuxt): Promise<ServerBundleOptions['collections']> {
+  const paths = getResolvePaths(nuxt)
+  const fullCollectionInstalled = hasFullCollection(nuxt)
+  const collections = fullCollectionInstalled
     ? collectionNames
-    : collectionNames.filter(collection => isPackageExists('@iconify-json/' + collection))
-  if (isFullCollectionExists)
+    : collectionNames.filter(collection => isPackageExists('@iconify-json/' + collection, { paths }))
+  if (fullCollectionInstalled)
     logger.success(`Nuxt Icon discovered local-installed ${collections.length} collections (@iconify/json)`)
   else if (collections.length)
     logger.success(`Nuxt Icon discovered local-installed ${collections.length} collections:`, collections.join(', '))
 
-  if (isFullCollectionExists)
+  if (fullCollectionInstalled)
     logger.warn('Currently all iconify collections are included in the bundle, which might be inefficient, consider explicit name the collections you use in the `icon.serverBundle.collections` option')
 
   return collections

--- a/src/context.ts
+++ b/src/context.ts
@@ -100,7 +100,7 @@ export class NuxtIconModuleContext {
     if (!resolved.collections)
       resolved.collections = resolved.remote
         ? collectionNames
-        : await discoverInstalledCollections()
+        : await discoverInstalledCollections(this.nuxt)
 
     const collections = await Promise.all(
       (resolved.collections || [])

--- a/src/module.ts
+++ b/src/module.ts
@@ -121,7 +121,7 @@ export default defineNuxtModule<ModuleOptions>({
 
       const collections = bundle.collections
         .filter(collection => typeof collection === 'string')
-        .map(collection => getCollectionPath(collection))
+        .map(collection => getCollectionPath(collection, nuxt))
       const resolvedPaths = await Promise.all(
         collections.map(collection => resolvePath(collection, {
           url: nuxt.options.rootDir,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Related https://github.com/nuxt/icon/issues/473

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Resolve `@iconify-json/*` auto-discovery from `nuxt.options.rootDir` / `workspaceDir` instead of `process.cwd()`, so collections installed in a subproject's `node_modules` are detected when `nuxt dev` is run from a pnpm workspace root.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
