### PR TITLE
fix(server): guard collection lookup against prototype keys

### DIFF
--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -27,7 +27,7 @@ export default defineCachedEventHandler(async (event: H3Event) => {
 
   const options = useAppConfig().icon as NuxtIconRuntimeOptions
   const collectionName = event.context.params?.collection?.replace(/\.json$/, '')
-  const collection = collectionName
+  const collection = collectionName && Object.hasOwn(collections, collectionName)
     ? await collections[collectionName]?.()
     : null
 


### PR DESCRIPTION
### 🔗 Linked issue

No related issue.

### 📚 Description

`src/runtime/server/api.ts` looks the collection up via `collections[collectionName]`, which also resolves inherited keys from `Object.prototype` (`__proto__`, `toString`, `constructor`, ...). The resolved value gets passed down to `getIcons()`,
which is not designed to handle it and crashes --> 500.

The fix is one line: gate the lookup with `Object.hasOwn(collections, collectionName)` so only own keys are considered. Unknown / prototype keys now fall through to the API fallback (or 404 if `fallbackToApi` is disabled), same as any other unknown collection.

Repro in the playground:

```bash
pnpm dev
curl -i 'http://localhost:3000/api/_nuxt_icon/toString.json?icons=bad'
```