### PR TITLE
fix(server): use `ufo` for query parsing to fix h3 v2 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "local-pkg": "^1.1.2",
     "mlly": "^1.8.2",
     "ohash": "^2.0.11",
-    "pathe": "^2.0.3",
     "picomatch": "^4.0.4",
     "std-env": "^4.1.0",
     "tinyglobby": "^0.2.16",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "pathe": "^2.0.3",
     "picomatch": "^4.0.4",
     "std-env": "^4.1.0",
-    "tinyglobby": "^0.2.16"
+    "tinyglobby": "^0.2.16",
+    "ufo": "^1.6.4"
   },
   "devDependencies": {
     "@iconify-json/fluent-emoji-high-contrast": "^1.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       tinyglobby:
         specifier: ^0.2.16
         version: 0.2.16
+      ufo:
+        specifier: ^1.6.4
+        version: 1.6.4
     devDependencies:
       '@iconify-json/fluent-emoji-high-contrast':
         specifier: ^1.2.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       ohash:
         specifier: ^2.0.11
         version: 2.0.11
-      pathe:
-        specifier: ^2.0.3
-        version: 2.0.3
       picomatch:
         specifier: ^4.0.4
         version: 4.0.4

--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -2,6 +2,7 @@ import { basename } from 'pathe'
 import { getIcons } from '@iconify/utils'
 import { hash } from 'ohash'
 import { createError, type H3Event } from 'h3'
+import { parseQuery, parsePath } from 'ufo'
 import { consola } from 'consola'
 import type { NuxtIconRuntimeOptions } from '../../schema-types'
 // @ts-expect-error tsconfig.server has the types
@@ -28,10 +29,6 @@ function getInstallCommand(pkg: string): string {
 }
 
 export default defineCachedEventHandler(async (event: H3Event) => {
-  const url = getRequestURL(event)
-  if (!url)
-    return createError({ status: 400, message: 'Invalid icon request' })
-
   const options = useAppConfig().icon as NuxtIconRuntimeOptions
   const collectionName = event.context.params?.collection?.replace(/\.json$/, '')
   const collection = collectionName
@@ -39,7 +36,8 @@ export default defineCachedEventHandler(async (event: H3Event) => {
     : null
 
   const apiEndPoint = options.iconifyApiEndpoint || DEFAULT_ENDPOINT
-  const icons = url.searchParams.get('icons')?.split(',')
+  const iconsQuery = parseQuery(parsePath(event.path).search).icons || ''
+  const icons = (Array.isArray(iconsQuery) ? iconsQuery.join(',') : iconsQuery).split(',')
 
   if (collection) {
     if (icons?.length) {
@@ -87,9 +85,9 @@ export default defineCachedEventHandler(async (event: H3Event) => {
   name: 'icon',
   getKey(event: H3Event) {
     const collection = event.context.params?.collection?.replace(/\.json$/, '') || 'unknown'
-    const url = getRequestURL(event)
-    const icons = url.searchParams.get('icons') || ''
-    return `${collection}_${icons.split(',')[0]}_${icons.length}_${hash(icons)}`
+    const iconsQuery = parseQuery(parsePath(event.path).search).icons || ''
+    const icons = (Array.isArray(iconsQuery) ? iconsQuery.join(',') : iconsQuery).split(',')
+    return `${collection}_${icons[0]}_${icons.length}_${hash(icons.join(','))}`
   },
   swr: true,
   maxAge: 60 * 60 * 24 * 7, // 1 week

--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -13,13 +13,6 @@ const warnOnceSet = /* @__PURE__ */ new Set<string>()
 
 const DEFAULT_ENDPOINT = 'https://api.iconify.design'
 
-// `getRequestURL` from h3 throws `ERR_INVALID_URL` under h3 v2 when `event.req.url`
-// is a relative path (e.g. internal SSR requests). `event.path` is relative in both
-// h3 v1 and v2, so parse it against a dummy base to safely access the query params.
-function getRequestURL(event: H3Event): URL {
-  return new URL(event.path, 'http://localhost')
-}
-
 function getInstallCommand(pkg: string): string {
   const ua = process.env.npm_config_user_agent || ''
   if (ua.startsWith('pnpm')) return `pnpm add -D ${pkg}`

--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -5,12 +5,19 @@ import { createError, type H3Event } from 'h3'
 import { consola } from 'consola'
 import type { NuxtIconRuntimeOptions } from '../../schema-types'
 // @ts-expect-error tsconfig.server has the types
-import { useAppConfig, getRequestURL, defineCachedEventHandler } from '#imports'
+import { useAppConfig, defineCachedEventHandler } from '#imports'
 import { collections } from '#nuxt-icon-server-bundle'
 
 const warnOnceSet = /* @__PURE__ */ new Set<string>()
 
 const DEFAULT_ENDPOINT = 'https://api.iconify.design'
+
+// `getRequestURL` from h3 throws `ERR_INVALID_URL` under h3 v2 when `event.req.url`
+// is a relative path (e.g. internal SSR requests). `event.path` is relative in both
+// h3 v1 and v2, so parse it against a dummy base to safely access the query params.
+function getRequestURL(event: H3Event): URL {
+  return new URL(event.path, 'http://localhost')
+}
 
 function getInstallCommand(pkg: string): string {
   const ua = process.env.npm_config_user_agent || ''
@@ -21,7 +28,7 @@ function getInstallCommand(pkg: string): string {
 }
 
 export default defineCachedEventHandler(async (event: H3Event) => {
-  const url = getRequestURL(event) as URL
+  const url = getRequestURL(event)
   if (!url)
     return createError({ status: 400, message: 'Invalid icon request' })
 
@@ -80,7 +87,7 @@ export default defineCachedEventHandler(async (event: H3Event) => {
   name: 'icon',
   getKey(event: H3Event) {
     const collection = event.context.params?.collection?.replace(/\.json$/, '') || 'unknown'
-    const url = getRequestURL(event) as URL
+    const url = getRequestURL(event)
     const icons = url.searchParams.get('icons') || ''
     return `${collection}_${icons.split(',')[0]}_${icons.length}_${hash(icons)}`
   },

--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -30,28 +30,26 @@ export default defineCachedEventHandler(async (event: H3Event) => {
   const apiEndPoint = options.iconifyApiEndpoint || DEFAULT_ENDPOINT
   const icons = String(parseQuery(parsePath(event.path).search).icons || '').split(',')
 
-  if (collection) {
-    if (icons?.length) {
-      const data = getIcons(
-        collection,
-        icons,
-      )
-      consola.debug(`[Icon] serving ${(icons || []).map(i => '`' + collectionName + ':' + i + '`').join(',')} from bundled collection`)
-      return data
-    }
-  }
-  else if (import.meta.dev) {
-    // Warn only once per collection, and only with the default endpoint
-    if (collectionName && !warnOnceSet.has(collectionName) && apiEndPoint === DEFAULT_ENDPOINT) {
-      consola.warn([
-        `[Icon] Collection \`${collectionName}\` is not found locally`,
-        `We suggest to install it via \`${getInstallCommand(`@iconify-json/${collectionName}`)}\` to provide the best end-user experience.`,
-      ].join('\n'))
-      warnOnceSet.add(collectionName)
-    }
+  if (!collectionName) return createError({ status: 400, message: 'No collection specified' })
+  if (!icons.length) return createError({ status: 400, message: 'No icons specified' })
+  if (!collection && import.meta.dev && !warnOnceSet.has(collectionName) && apiEndPoint === DEFAULT_ENDPOINT) {
+    consola.warn([
+      `[Icon] Collection \`${collectionName}\` is not found locally`,
+      `We suggest to install it via \`${getInstallCommand(`@iconify-json/${collectionName}`)}\` to provide the best end-user experience.`,
+    ].join('\n'))
+    warnOnceSet.add(collectionName)
   }
 
-  if (collectionName && (options.fallbackToApi === true || options.fallbackToApi === 'server-only')) {
+  if (collection) {
+    const data = getIcons(
+      collection,
+      icons,
+    )
+    consola.debug(`[Icon] serving ${(icons).map(i => '`' + collectionName + ':' + i + '`').join(',')} from bundled collection`)
+    return data
+  }
+
+  if (options.fallbackToApi === true || options.fallbackToApi === 'server-only') {
     const apiUrl = new URL(`./${collectionName}.json?icons=${icons.join(',')}`, apiEndPoint)
     consola.debug(`[Icon] fetching ${(icons).map(i => '`' + collectionName + ':' + i + '`').join(',')} from iconify api`)
     if (apiUrl.host !== new URL(apiEndPoint).host) {

--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -1,4 +1,3 @@
-import { basename } from 'pathe'
 import { getIcons } from '@iconify/utils'
 import { hash } from 'ohash'
 import { createError, type H3Event } from 'h3'
@@ -29,8 +28,7 @@ export default defineCachedEventHandler(async (event: H3Event) => {
     : null
 
   const apiEndPoint = options.iconifyApiEndpoint || DEFAULT_ENDPOINT
-  const iconsQuery = parseQuery(parsePath(event.path).search).icons || ''
-  const icons = (Array.isArray(iconsQuery) ? iconsQuery.join(',') : iconsQuery).split(',')
+  const icons = String(parseQuery(parsePath(event.path).search).icons || '').split(',')
 
   if (collection) {
     if (icons?.length) {
@@ -53,9 +51,9 @@ export default defineCachedEventHandler(async (event: H3Event) => {
     }
   }
 
-  if (options.fallbackToApi === true || options.fallbackToApi === 'server-only') {
-    const apiUrl = new URL('./' + basename(url.pathname) + url.search, apiEndPoint)
-    consola.debug(`[Icon] fetching ${(icons || []).map(i => '`' + collectionName + ':' + i + '`').join(',')} from iconify api`)
+  if (collectionName && (options.fallbackToApi === true || options.fallbackToApi === 'server-only')) {
+    const apiUrl = new URL(`./${collectionName}.json?icons=${icons.join(',')}`, apiEndPoint)
+    consola.debug(`[Icon] fetching ${(icons).map(i => '`' + collectionName + ':' + i + '`').join(',')} from iconify api`)
     if (apiUrl.host !== new URL(apiEndPoint).host) {
       return createError({ status: 400, message: 'Invalid icon request' })
     }
@@ -78,8 +76,7 @@ export default defineCachedEventHandler(async (event: H3Event) => {
   name: 'icon',
   getKey(event: H3Event) {
     const collection = event.context.params?.collection?.replace(/\.json$/, '') || 'unknown'
-    const iconsQuery = parseQuery(parsePath(event.path).search).icons || ''
-    const icons = (Array.isArray(iconsQuery) ? iconsQuery.join(',') : iconsQuery).split(',')
+    const icons = String(parseQuery(parsePath(event.path).search).icons || '').split(',')
     return `${collection}_${icons[0]}_${icons.length}_${hash(icons.join(','))}`
   },
   swr: true,

--- a/src/runtime/server/api.ts
+++ b/src/runtime/server/api.ts
@@ -1,7 +1,7 @@
 import { basename } from 'pathe'
 import { getIcons } from '@iconify/utils'
 import { hash } from 'ohash'
-import { createError, getQuery, type H3Event } from 'h3'
+import { createError, type H3Event } from 'h3'
 import { consola } from 'consola'
 import type { NuxtIconRuntimeOptions } from '../../schema-types'
 // @ts-expect-error tsconfig.server has the types
@@ -80,7 +80,8 @@ export default defineCachedEventHandler(async (event: H3Event) => {
   name: 'icon',
   getKey(event: H3Event) {
     const collection = event.context.params?.collection?.replace(/\.json$/, '') || 'unknown'
-    const icons = String(getQuery(event).icons || '')
+    const url = getRequestURL(event) as URL
+    const icons = url.searchParams.get('icons') || ''
     return `${collection}_${icons.split(',')[0]}_${icons.length}_${hash(icons)}`
   },
   swr: true,


### PR DESCRIPTION
## Summary

- Stop using h3's `getQuery`/`getRequestURL` in the icon API handler and `getKey`. Both throw `ERR_INVALID_URL` under h3 v2.
- Parse `event.path` using `ufo` `parsePath` and `parseQuery` for h3 v1 and v2 compatibility
