### PR TITLE
chore(github): add pkg.pr.new preview publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Test
         run: npm run test
+
+      - name: Publish
+        run: pnpx pkg-pr-new publish --compact --no-template --pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,5 @@ jobs:
         run: npm run test
 
       - name: Publish
+        if: github.repository_owner == 'nuxt'
         run: pnpx pkg-pr-new publish --compact --no-template --pnpm


### PR DESCRIPTION
## Summary

- Adds a `pkg-pr-new publish` step to CI after build and tests
- Uses `--compact --no-template --pnpm` to match other Nuxt modules

## Motivation

Enables continuous preview releases on PRs and pushes to `main`, so consumers can install `@nuxt/icon` from `pkg.pr.new` without waiting for an npm publish.

## Setup

The [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) must be installed on this repository before the publish step succeeds.

## Test plan

- [ ] Merge after installing the pkg.pr.new app on the repo
- [ ] Open or update a PR and confirm CI posts a preview install comment
- [ ] Verify `pnpm add https://pkg.pr.new/@nuxt/icon@<sha>` installs the built module