### PR TITLE
fix: resolve client bundle collections from rootDir/workspaceDir

### DIFF
--- a/src/collections.ts
+++ b/src/collections.ts
@@ -9,7 +9,7 @@ import { isPackageExists } from 'local-pkg'
 import { collectionNames } from './collection-names'
 import type { CustomCollection, ServerBundleOptions, RemoteCollection } from './types'
 
-function getResolvePaths(nuxt: Nuxt): string[] {
+export function getResolvePaths(nuxt: Nuxt): string[] {
   return Array.from(new Set(
     [nuxt.options.rootDir, nuxt.options.workspaceDir].filter(Boolean),
   ))

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,7 +4,7 @@ import { provider } from 'std-env'
 import { logger } from '@nuxt/kit'
 import { collectionNames } from './collection-names'
 import type { ModuleOptions, NuxtIconRuntimeOptions, ResolvedServerBundleOptions } from './types'
-import { discoverInstalledCollections, loadCustomCollection, resolveCollection } from './collections'
+import { discoverInstalledCollections, getResolvePaths, loadCustomCollection, resolveCollection } from './collections'
 import { IconUsageScanner } from './scan'
 
 const KEYWORDS_EDGE_TARGETS: string[] = [
@@ -187,15 +187,26 @@ export class NuxtIconModuleContext {
     const customCollectionNames = new Set(customCollections.map(c => c.prefix))
     const collections = new Map<string, IconifyJSON>()
 
-    function loadCollection(prefix: string) {
+    // Resolve collections from the Nuxt root (and workspace root as a fallback)
+    // instead of `process.cwd()`, so collections installed in a subproject are
+    // found when the command is launched from a workspace root.
+    const resolvePaths = getResolvePaths(this.nuxt)
+
+    async function loadCollection(prefix: string): Promise<IconifyJSON | undefined> {
       if (customCollectionNames.has(prefix)) {
         const collection = customCollections.find(c => c.prefix === prefix)
         if (collection) {
-          return Promise.resolve(collection)
+          return collection
         }
       }
 
-      return loadCollectionFromFS(prefix)
+      for (const cwd of resolvePaths) {
+        const collection = await loadCollectionFromFS(prefix, false, '@iconify-json', cwd)
+        if (collection) {
+          return collection
+        }
+      }
+      return undefined
     }
 
     function addIcon(prefix: string, name: string, data: IconifyIcon) {

--- a/test/client-bundle.test.ts
+++ b/test/client-bundle.test.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, expect, it } from 'vitest'
+import { NuxtIconModuleContext } from '../src/context'
+
+// Install a fake `@iconify-json/<prefix>` collection into `<dir>/node_modules`
+function installCollection(dir: string, prefix: string, icon: string) {
+  const collectionDir = join(dir, 'node_modules', '@iconify-json', prefix)
+  mkdirSync(collectionDir, { recursive: true })
+  writeFileSync(join(collectionDir, 'package.json'), JSON.stringify({
+    name: `@iconify-json/${prefix}`,
+    version: '0.0.0',
+    main: 'index.js',
+    exports: {
+      './*': './*',
+      './icons.json': './icons.json',
+    },
+  }))
+  writeFileSync(join(collectionDir, 'icons.json'), JSON.stringify({
+    prefix,
+    icons: {
+      [icon]: { body: '<path d="M0 0h24v24H0z"/>' },
+    },
+    width: 24,
+    height: 24,
+  }))
+}
+
+function createContext(rootDir: string, workspaceDir: string, icons: string[]) {
+  const nuxt = {
+    options: { rootDir, workspaceDir },
+    callHook: async () => {},
+  }
+  return new NuxtIconModuleContext(nuxt as never, {
+    clientBundle: { icons },
+  } as never)
+}
+
+// The collection lives in a subproject's `node_modules` while the command is
+// launched from a workspace root (`process.cwd()`), so it can only be resolved
+// from `nuxt.options.rootDir` / `workspaceDir`, never from `process.cwd()`.
+let root: string
+const appDir = () => join(root, 'app')
+const wsDir = () => join(root, 'ws')
+const emptyDir = () => join(root, 'empty')
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'nuxt-icon-client-bundle-'))
+  installCollection(appDir(), 'nuxt-icon-test', 'foo')
+  installCollection(wsDir(), 'nuxt-icon-test-ws', 'bar')
+  mkdirSync(emptyDir(), { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+it('resolves client bundle collections from rootDir, not process.cwd()', async () => {
+  const context = createContext(appDir(), appDir(), ['nuxt-icon-test:foo'])
+  const result = await context.loadClientBundleCollections()
+
+  expect(result.failed).toEqual([])
+  expect(result.count).toBe(1)
+  expect(result.collections.find(c => c.prefix === 'nuxt-icon-test')?.icons.foo).toBeTruthy()
+})
+
+it('falls back to workspaceDir when the collection is not under rootDir', async () => {
+  // `rootDir` has no collection and is not nested under `workspaceDir`, so the
+  // first lookup returns undefined and resolution must fall back to workspaceDir.
+  const context = createContext(emptyDir(), wsDir(), ['nuxt-icon-test-ws:bar'])
+  const result = await context.loadClientBundleCollections()
+
+  expect(result.failed).toEqual([])
+  expect(result.count).toBe(1)
+  expect(result.collections.find(c => c.prefix === 'nuxt-icon-test-ws')?.icons.bar).toBeTruthy()
+})


### PR DESCRIPTION
### 📚 Description

The client-bundle loader resolved `@iconify-json/*` collections from `process.cwd()`, so collections installed in a subproject's `node_modules` were not found when the command was launched from a workspace root (e.g. running `nuxt dev` from a pnpm workspace root while `@iconify-json/lucide` lives in `playgrounds/app/node_modules`). The build then failed with *"Nuxt Icon could not fetch the icon data for client bundle"*.

#477 already fixed this class of bug for the **server bundle** and `discoverInstalledCollections` by resolving from `[rootDir, workspaceDir]`. The client-bundle loader in `src/context.ts` was the one spot it didn't cover.

This resolves collections from `nuxt.options.rootDir`, falling back to `workspaceDir` (since `loadCollectionFromFS` accepts a single `cwd` and caches by it), reusing the now-exported `getResolvePaths(nuxt)` helper.

### Test

Added `test/client-bundle.test.ts` covering both the `rootDir` resolution and the `workspaceDir` fallback. The collection is installed into a temp `node_modules` (committing under `node_modules` isn't possible — it's git-ignored) while `process.cwd()` is elsewhere, mimicking a workspace-root launch. Both cases fail before this change and pass after.
