### PR TITLE
fix: don't hard-fail on unresolvable hook-contributed client bundle icons

### DIFF
--- a/src/bundle-client.ts
+++ b/src/bundle-client.ts
@@ -18,7 +18,7 @@ export function registerClientBundle(
       } = ctx.options.clientBundle || {}
 
       // TODO: find a granular way to cache this
-      const { collections, count, failed } = await ctx.loadClientBundleCollections()
+      const { collections, count, failed, dropped } = await ctx.loadClientBundleCollections()
 
       if (cacheSize === count && cacheData && cacheVersion === ctx.clientBundleVersion) {
         return cacheData
@@ -30,6 +30,10 @@ export function registerClientBundle(
           throw new Error(msg)
         else
           logger.warn(msg)
+      }
+
+      if (dropped.length) {
+        logger.warn(`Nuxt Icon could not resolve these icons for the client bundle, falling back to runtime loading:\n${dropped.map(f => ' - ' + f).join('\n')}`)
       }
 
       if (!collections.length)

--- a/src/context.ts
+++ b/src/context.ts
@@ -143,7 +143,7 @@ export class NuxtIconModuleContext {
     )
   }
 
-  async loadClientBundleCollections(): Promise<{ collections: IconifyJSON[], count: number, failed: string[] }> {
+  async loadClientBundleCollections(): Promise<{ collections: IconifyJSON[], count: number, failed: string[], dropped: string[] }> {
     const {
       includeCustomCollections = this.options.provider !== 'server',
       scan = false,
@@ -173,6 +173,7 @@ export class NuxtIconModuleContext {
         count: 0,
         collections: [],
         failed: [],
+        dropped: [],
       }
     }
 
@@ -182,6 +183,7 @@ export class NuxtIconModuleContext {
     const { loadCollectionFromFS } = await import('@iconify/utils/lib/loader/fs')
 
     const failed: string[] = []
+    const dropped: string[] = []
     let count = 0
 
     const customCollectionNames = new Set(customCollections.map(c => c.prefix))
@@ -239,9 +241,17 @@ export class NuxtIconModuleContext {
           data = getIconData(collection, name)
 
         if (!data) {
-          // We don't warn for scanned icons, because the extraction can have false positives
-          if (!this.scannedIcons.has(icon) || userIcons.has(icon)) {
+          // Only icons the user explicitly listed in `clientBundle.icons` hard-fail
+          // the build. Scanned and hook-contributed icons are best-effort: drop them
+          // from the bundle and fall back to runtime loading.
+          if (userIcons.has(icon)) {
             failed.push(icon)
+          }
+          // We don't warn for scanned icons, because the extraction can have false
+          // positives; hook-contributed icons are surfaced so module authors get a
+          // heads-up that something couldn't be bundled.
+          else if (!this.scannedIcons.has(icon)) {
+            dropped.push(icon)
           }
         }
         else {
@@ -273,6 +283,7 @@ export class NuxtIconModuleContext {
       collections: [...collections.values()],
       count,
       failed,
+      dropped,
     }
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -260,7 +260,14 @@ export class NuxtIconModuleContext {
       }
       catch (e) {
         console.error(e)
-        failed.push(icon)
+        // Mirror the best-effort handling above: only explicit user icons hard-fail,
+        // scanned/hook-contributed icons fall back to runtime loading.
+        if (userIcons.has(icon)) {
+          failed.push(icon)
+        }
+        else if (!this.scannedIcons.has(icon)) {
+          dropped.push(icon)
+        }
       }
     }))
 

--- a/test/client-bundle.test.ts
+++ b/test/client-bundle.test.ts
@@ -27,10 +27,14 @@ function installCollection(dir: string, prefix: string, icon: string) {
   }))
 }
 
-function createContext(rootDir: string, workspaceDir: string, icons: string[]) {
+function createContext(rootDir: string, workspaceDir: string, icons: string[], hookIcons: string[] = []) {
   const nuxt = {
     options: { rootDir, workspaceDir },
-    callHook: async () => {},
+    // Mimic a module contributing icons through the `icon:clientBundleIcons` hook
+    callHook: async (_name: string, set: Set<string>) => {
+      for (const icon of hookIcons)
+        set.add(icon)
+    },
   }
   return new NuxtIconModuleContext(nuxt as never, {
     clientBundle: { icons },
@@ -74,4 +78,37 @@ it('falls back to workspaceDir when the collection is not under rootDir', async 
   expect(result.failed).toEqual([])
   expect(result.count).toBe(1)
   expect(result.collections.find(c => c.prefix === 'nuxt-icon-test-ws')?.icons.bar).toBeTruthy()
+})
+
+it('does not hard-fail when a hook-contributed icon cannot be resolved', async () => {
+  // A module adds an icon from a collection that is not installed. It must be
+  // best-effort: omitted from the bundle (so it falls back to runtime loading)
+  // and never added to `failed` (which would throw in a production build).
+  const context = createContext(appDir(), appDir(), ['nuxt-icon-test:foo'], ['not-installed:missing'])
+  const result = await context.loadClientBundleCollections()
+
+  expect(result.failed).toEqual([])
+  expect(result.dropped).toEqual(['not-installed:missing'])
+  expect(result.count).toBe(1)
+  expect(result.collections.find(c => c.prefix === 'not-installed')).toBeUndefined()
+  expect(result.collections.find(c => c.prefix === 'nuxt-icon-test')?.icons.foo).toBeTruthy()
+})
+
+it('does not hard-fail when a hook-contributed icon name does not exist in an installed collection', async () => {
+  // The collection is installed but the specific icon name does not exist
+  // (e.g. version skew). Still best-effort, not a hard failure.
+  const context = createContext(appDir(), appDir(), [], ['nuxt-icon-test:does-not-exist'])
+  const result = await context.loadClientBundleCollections()
+
+  expect(result.failed).toEqual([])
+  expect(result.dropped).toEqual(['nuxt-icon-test:does-not-exist'])
+  expect(result.count).toBe(0)
+})
+
+it('still hard-fails when an icon explicitly listed in clientBundle.icons cannot be resolved', async () => {
+  const context = createContext(appDir(), appDir(), ['not-installed:missing'])
+  const result = await context.loadClientBundleCollections()
+
+  expect(result.failed).toEqual(['not-installed:missing'])
+  expect(result.dropped).toEqual([])
 })


### PR DESCRIPTION
### 📚 Description

Icons contributed by modules through the `icon:clientBundleIcons` hook hard-failed the build when they couldn't be resolved, even though scanned icons in the same situation already fall back to runtime loading.

Now only icons explicitly listed in `clientBundle.icons` hard-fail. Scanned and hook-contributed icons are best-effort; unresolvable hook icons are warned about rather than thrown.

This unblocks nuxt/ui#6633, which can now drop its filesystem collection-presence check and rely on @nuxt/icon to skip whatever it can't resolve.

### Test

Extended `test/client-bundle.test.ts`: a hook-contributed icon whose collection/name can't be resolved is omitted rather than throwing, while an unresolvable icon in `clientBundle.icons` still fails the build.