### PR TITLE
fix: avoid relying on global fetch

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,13 +1,14 @@
 import { addAPIProvider, _api, setCustomIconsLoader } from '@iconify/vue'
 import type { IconifyJSON } from '@iconify/types'
 import type { NuxtIconRuntimeOptions } from '../types'
-import { defineNuxtPlugin, useAppConfig, useRuntimeConfig } from '#imports'
+import { defineNuxtPlugin, useAppConfig, useRequestFetch, useRuntimeConfig } from '#imports'
 
 export default defineNuxtPlugin({
   name: '@nuxt/icon',
   setup() {
     const configs = useRuntimeConfig()
     const options = useAppConfig().icon as NuxtIconRuntimeOptions
+    const $fetch = useRequestFetch()
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore type incompatible


### PR DESCRIPTION
Nuxt PR nuxt/nuxt#35790 stopped installing `$fetch` on `globalThis` in the client when it is otherwise unused.

The runtime plugin still read that global during setup, so this uses `useRequestFetch()` to obtain Nuxt's configured fetch instance while preserving compatibility with existing Nuxt releases.

---

*This pull request was created with assistance from a code agent.*
