### PR TITLE
fix(client-bundle): don't warn end users about dropped integration icons

### DIFF
--- a/src/bundle-client.ts
+++ b/src/bundle-client.ts
@@ -33,8 +33,11 @@ export function registerClientBundle(
           logger.warn(msg)
       }
 
+      // `dropped` icons come from integrations via the `icon:clientBundleIcons` hook, not
+      // from the user, so a warning is noise they can't act on. They already fall back to
+      // runtime loading, so keep it at debug level for anyone inspecting the bundle.
       if (dropped.length) {
-        logger.warn(`Nuxt Icon could not resolve these icons for the client bundle, falling back to runtime loading:\n${dropped.map(f => ' - ' + f).join('\n')}`)
+        logger.debug(`Nuxt Icon could not resolve these icons for the client bundle, falling back to runtime loading:\n${dropped.map(f => ' - ' + f).join('\n')}`)
       }
 
       const { code, bundleSizeKb } = generateClientBundleCode(collections, { sizeLimitKb })


### PR DESCRIPTION
### 🔗 Linked issue

Fixes the noisy warnings reported downstream in nuxt/ui#6755 (also the symptom half of nuxt/ui#6763, though that issue's actual ask, pre-bundling the overridden icons, is a separate Nuxt UI change).

### ❓ Type of change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

### 📚 Description

When an integration contributes icons through the `icon:clientBundleIcons` hook (this is how Nuxt UI pre-bundles its default icons), anything the client bundle can't resolve ends up in `dropped` and gets logged with `logger.warn` on every build:

```
WARN  Nuxt Icon could not resolve these icons for the client bundle, falling back to runtime loading:
 - lucide:arrow-down
 - lucide:check
 ...
```

The problem is that `dropped` icons are contributed by the integration, not requested by the end user, so the end user can't act on the warning. A library defaulting to a collection the app hasn't installed (Nuxt UI defaults to lucide but ships no `@iconify-json/*` dependency) triggers it, and it's especially confusing when the user has overridden those icons to a collection they do have. They already fall back to runtime loading, exactly as documented for the `extraIcons` tier, so nothing is actually broken, it's just loud.

This keeps the `failed` path untouched (a user's own `clientBundle.icons` that can't resolve still warns in dev and throws on build, since that one is actionable) and only moves the `dropped` message down to `logger.debug`, so it's still there under `DEBUG`/verbose for anyone debugging their bundle. `resolveBundleIcons` still returns `dropped` unchanged, so integrations that want to surface it with their own context can keep reading it.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
