### PR TITLE
fix(server-bundle): keep the `with` key on externalized icon JSON imports

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -154,6 +154,14 @@ export default defineNuxtModule<ModuleOptions>({
             return { id, external: true }
           }
         },
+        // Rollup 4 re-prints the import attributes of external modules with the `assert`
+        // key (`output.importAttributesKey`, switching to `with` only in Rollup 5), and
+        // Node.js removed `assert` in v22 — the icon API then fails at runtime with
+        // `ERR_IMPORT_ATTRIBUTE_MISSING`. Keep the key the generated code already uses.
+        outputOptions(options: { importAttributesKey?: 'assert' | 'with' }) {
+          options.importAttributesKey ||= 'with'
+          return options
+        },
       })
     })
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #522

### 📚 Description

`externalizeIconsJson` generates `import('@iconify-json/…/icons.json', { with: { type: 'json' } })`
(`src/bundle-server.ts:57`), but Rollup 4 re-prints the attributes of external modules with its own
default key, `assert` — and Node.js removed `assert` in v22, so the icon API 500s with
`ERR_IMPORT_ATTRIBUTE_MISSING` while the build stays green. Same user-visible error as #186, which
#187 fixed by adding the attribute; this time it's written correctly and lost downstream.

Rollup only flips that default in v5 (rollup/rollup#6248, merged to `rollup-5`, unreleased). Nitro
has the same gap and I've filed nitrojs/nitro#4518 for it, but a fix there won't reach anyone on a
released Nitro — and this module is the one that creates the external import. So it sets the key
itself, from the plugin it already installs, via `outputOptions`: `||=` leaves an explicit user
setting alone, it works whether the build has one output or several, and nothing outside this
plugin is touched.

After this, the README's promise — "in the final build, it will contain statements like
`() => import('@iconify-json/ph/icons.json', { with: { type: 'json' } })`" — holds again.

### Verification

In `playgrounds/nuxt`, with `serverBundle: { externalizeIconsJson: true }` and `pnpm play:build`:

```
# before
.output/server/chunks/_/nitro.mjs: import('@iconify-json/ph/icons.json', { assert: { type: 'json' } })
# after
.output/server/chunks/_/nitro.mjs: import('@iconify-json/ph/icons.json', { with: { type: 'json' } })
```

The underlying Rollup/Nitro behaviour, on plain Nitro without Nuxt (so the 500 and the 200 are easy
to see): https://github.com/agantelin/nitro-import-attributes-repro

No unit test: the hook this touches is the `nitro:config` one, which the current suite doesn't
exercise, and the playground build above is the honest check. Glad to add one if you'd like it
covered.
