### PR TITLE
fix: register server handler only for server provider

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -92,10 +92,12 @@ export default defineNuxtModule<ModuleOptions>({
       global: true,
       filePath: await resolver.resolvePath('./runtime/components/index'),
     })
-    addServerHandler({
-      route: `${options.localApiEndpoint || '/api/_nuxt_icon'}/:collection`,
-      handler: resolver.resolve('./runtime/server/api'),
-    })
+    if (options.provider === 'server') {
+      addServerHandler({
+        route: `${options.localApiEndpoint || '/api/_nuxt_icon'}/:collection`,
+        handler: resolver.resolve('./runtime/server/api'),
+      })
+    }
 
     await setupCustomCollectionsWatcher(options, nuxt, ctx)
 

--- a/test/fixtures/iconify-provider/nuxt.config.ts
+++ b/test/fixtures/iconify-provider/nuxt.config.ts
@@ -1,0 +1,10 @@
+import NuxtIcon from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    [NuxtIcon, {
+      provider: 'iconify',
+      serverBundle: false,
+    }],
+  ],
+})

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { setup, useTestContext } from '@nuxt/test-utils/e2e'
+
+describe('module', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/iconify-provider', import.meta.url)),
+    build: true,
+    server: false,
+  })
+
+  it('does not register the local API handler for the iconify provider', () => {
+    const handlers = useTestContext().nuxt?.options.serverHandlers
+
+    expect(handlers).not.toContainEqual(expect.objectContaining({
+      route: '/api/_nuxt_icon/:collection',
+    }))
+  })
+})


### PR DESCRIPTION
## Summary

When `provider` is `iconify`, the client loads icons from the Iconify API and the server bundle resolver disables the server bundle, but the module still registers the local `/api/_nuxt_icon/:collection` handler. This change registers that handler only for the `server` provider.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-icon-non-server-handler](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-icon-non-server-handler/nuxt-icon-non-server-handler?startScript=repro) | ❌ The assertion detects the unused local handler |
| Fix | [nuxt-icon-non-server-handler-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-icon-non-server-handler/nuxt-icon-non-server-handler-fix?startScript=repro) | ✅ The production build completes without the local handler |

## CLI reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-icon-non-server-handler https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-icon-non-server-handler
cd nuxt-icon-non-server-handler && pnpm i && pnpm repro
```

## Verify fix

```bash
git sparse-checkout add nuxt-icon-non-server-handler-fix
cd ../nuxt-icon-non-server-handler-fix && pnpm i && pnpm repro
```

## Tests

- `pnpm test:unit --run`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
