### PR TITLE
fix: added adapter to fix the SSR Icon missing error

### DIFF
--- a/playgrounds/nuxt5/test.mjs
+++ b/playgrounds/nuxt5/test.mjs
@@ -31,6 +31,12 @@ async function waitForServer() {
 try {
   await waitForServer()
 
+  const page = await fetchWithTimeout(origin)
+  assert.equal(page.status, 200)
+  const pageHtml = await page.text()
+  assert.match(pageHtml, /class="iconify i-ph:acorn-bold"/)
+  assert.match(pageHtml, /data:image\/svg\+xml/)
+
   const bundled = await fetchWithTimeout(`${origin}/api/_nuxt_icon/ph.json?icons=acorn-bold`)
   assert.equal(bundled.status, 200)
   const bundledData = await bundled.json()

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,18 +1,26 @@
 import { addAPIProvider, _api, setCustomIconsLoader } from '@iconify/vue'
 import type { IconifyJSON } from '@iconify/types'
 import type { NuxtIconRuntimeOptions } from '../types'
-import { defineNuxtPlugin, useAppConfig, useRequestFetch, useRuntimeConfig } from '#imports'
+import { defineNuxtPlugin, tryUseNuxtApp, useAppConfig, useRequestFetch, useRuntimeConfig } from '#imports'
 
 export default defineNuxtPlugin({
   name: '@nuxt/icon',
   setup() {
     const configs = useRuntimeConfig()
     const options = useAppConfig().icon as NuxtIconRuntimeOptions
-    const $fetch = useRequestFetch()
+    const requestFetch = useRequestFetch()
+    const nativeFetch = (requestFetch as { native?: typeof globalThis.fetch }).native
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore type incompatible
-    _api.setFetch($fetch.native)
+    _api.setFetch((input, init) => {
+      const event = tryUseNuxtApp()?.ssrContext?.event as { fetch?: typeof globalThis.fetch } | undefined
+      const nitroFetch = (globalThis as typeof globalThis & {
+        $fetch?: { native?: typeof globalThis.fetch }
+      }).$fetch?.native
+
+      // Prefer request-aware fetch, but Nitro 2's useRequestFetch() has no `.native`.
+      // Its global native fetch keeps deferred relative requests local without retaining an event.
+      return (event?.fetch || nativeFetch || nitroFetch || globalThis.fetch)(input, init)
+    })
 
     const resources: string[] = []
     if (options.provider === 'server') {
@@ -33,7 +41,7 @@ export default defineNuxtPlugin({
 
     async function customIconLoader(icons: string[], prefix: string): Promise<IconifyJSON | null> {
       try {
-        const data = await $fetch(resources[0] + '/' + prefix + '.json', {
+        const data = await requestFetch(resources[0] + '/' + prefix + '.json', {
           query: {
             icons: icons.join(','),
           },

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,7 +1,7 @@
 import { addAPIProvider, _api, setCustomIconsLoader } from '@iconify/vue'
 import type { IconifyJSON } from '@iconify/types'
 import type { NuxtIconRuntimeOptions } from '../types'
-import { defineNuxtPlugin, tryUseNuxtApp, useAppConfig, useRequestFetch, useRuntimeConfig } from '#imports'
+import { defineNuxtPlugin, useAppConfig, useRequestFetch, useRuntimeConfig } from '#imports'
 
 export default defineNuxtPlugin({
   name: '@nuxt/icon',
@@ -12,14 +12,10 @@ export default defineNuxtPlugin({
     const nativeFetch = (requestFetch as { native?: typeof globalThis.fetch }).native
 
     _api.setFetch((input, init) => {
-      const event = tryUseNuxtApp()?.ssrContext?.event as { fetch?: typeof globalThis.fetch } | undefined
       const nitroFetch = (globalThis as typeof globalThis & {
         $fetch?: { native?: typeof globalThis.fetch }
       }).$fetch?.native
-
-      // Prefer request-aware fetch, but Nitro 2's useRequestFetch() has no `.native`.
-      // Its global native fetch keeps deferred relative requests local without retaining an event.
-      return (event?.fetch || nativeFetch || nitroFetch || globalThis.fetch)(input, init)
+      return (nativeFetch || nitroFetch || globalThis.fetch)(input, init)
     })
 
     const resources: string[] = []

--- a/test/fixtures/ssr-runtime/app.vue
+++ b/test/fixtures/ssr-runtime/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <Icon name="ph:acorn-bold" />
+</template>

--- a/test/fixtures/ssr-runtime/nuxt.config.ts
+++ b/test/fixtures/ssr-runtime/nuxt.config.ts
@@ -1,0 +1,11 @@
+import Module from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [Module],
+  icon: {
+    fallbackToApi: false,
+    serverBundle: {
+      collections: ['ph'],
+    },
+  },
+})

--- a/test/ssr.test.ts
+++ b/test/ssr.test.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { fetch, getServerLogs, setup } from '@nuxt/test-utils/e2e'
+
+describe('SSR runtime icon loading', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/ssr-runtime', import.meta.url)),
+    build: true,
+    server: true,
+    browser: false,
+  })
+
+  it('renders icons from the local server provider', async () => {
+    const response = await fetch('/')
+    const html = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(html).toContain('class="iconify i-ph:acorn-bold"')
+    expect(html).toContain('data:image/svg+xml')
+    expect(getServerLogs().join('\n')).not.toContain('[Icon] failed to load icon')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #518.

### 📚 Description

After updating the `nuxt/icon` up from `@2.3.1` the icons fail to render if app uses SSR. For ex:

```bash
 WARN  [Icon] failed to load icon lucide:sun 
```

Related issue describes the core regression correctly.

### Solution

The simple priority logic to pick correcrt `fetch` was added to resolve both initial issue #514 (where regression appeared) and remove that regression.

Here's the logic behind the prioritization:

1. Pick `event.fetch` if it is available as the most "context-rich": relative Nitro routes, preserving request’s headers and context, base URL, etc.
2. Pick `useRequestFetch().native` if it is available. Used in browser (or future Nuxt 5) and keeping fix by #514.
Here's the regression, as Nuxt 4/Nitro 2 `useRequestFetch()` doesn't expose `.native`.
3. Pick `globalThis.$fetch.native` as the Nuxt 4/Nitro 2 SSR compatibility path.
4. Pick `globalThis.fetch` as the final safety net.

I also added fixture, expanded smoke and wrote regression tests.