### PR TITLE
fix(scan): don't extract icon names from the middle of identifiers

### DIFF
--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -79,5 +79,12 @@ export function createMatchRegex(
   collections: string[] | Set<string>,
 ) {
   const collectionsRegex = [...collections].sort((a, b) => b.length - a.length).join('|')
-  return new RegExp('\\b(?:i-)?(' + collectionsRegex + ')[:-]([a-z0-9-]+)\\b', 'g')
+  // `(?<![\w-])` / `(?![\w-])`: a reference never starts or ends in the middle of a
+  // longer identifier, so `source-map-js` is not `map:js` and `--gg-size` is not
+  // `gg:size`. `\b` alone let both through, because a `-` is a word boundary.
+  //
+  // The name follows Iconify's own icon name grammar, which has no leading,
+  // doubled or trailing `-`, so a name that cannot exist is never extracted:
+  // https://github.com/iconify/iconify/blob/2274c033b49c01a50dc89b490b89d803d19d95dc/packages/utils/src/icon/name.ts#L15-L18
+  return new RegExp('(?<![\\w-])(?:i-)?(' + collectionsRegex + ')[:-]([a-z0-9]+(?:-[a-z0-9]+)*)(?![\\w-])', 'g')
 }

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -18,3 +18,40 @@ it('extract icon usages', async () => {
     }
   `)
 })
+
+function extract(code: string) {
+  const set = new Set<string>()
+  new IconUsageScanner({}).extractFromCode(code, set)
+  return [...set]
+}
+
+it('extracts every supported way of writing an icon name', () => {
+  expect(extract('<Icon name="mdi:home" />')).toEqual(['mdi:home'])
+  expect(extract('<Icon name="mdi-home" />')).toEqual(['mdi:home'])
+  expect(extract('<div class="i-mdi-home" />')).toEqual(['mdi:home'])
+  expect(extract('<div class="i-mdi:home" />')).toEqual(['mdi:home'])
+  expect(extract('<div class="dark:i-mdi-home" />')).toEqual(['mdi:home'])
+  // A collection whose own name contains a `-`, and a name with digits
+  expect(extract('<Icon name="mdi-light:home" />')).toEqual(['mdi-light:home'])
+  expect(extract('<Icon name="uil:0-plus" />')).toEqual(['uil:0-plus'])
+  // The form the playground uses
+  expect(extract(`icon: 'logos-nuxt-icon'`)).toEqual(['logos:nuxt-icon'])
+})
+
+it('does not extract from the middle of a longer identifier', () => {
+  // `map`, `vs` and `ix` are collection prefixes, but none of these is a usage
+  expect(extract(`import 'source-map-js'`)).toEqual([])
+  expect(extract('see undici-vs-builtin-fetch.md')).toEqual([])
+  expect(extract('<img src="https://images.example.com/n-ix-ltd/logo.png">')).toEqual([])
+  // A CSS custom property, not the `gg` collection
+  expect(extract('<div style="--gg-size: 4px" />')).toEqual([])
+})
+
+it('never extracts a name that Iconify could not accept', () => {
+  // `memory` is a collection prefix; the old pattern captured `efficient-`,
+  // trailing `-` and all, because the uppercase `L` closed the word boundary
+  expect(extract('Fast-memory-efficient-Levenshtein')).toEqual([])
+  expect(extract('<Icon name="mdi--home" />')).toEqual([])
+  for (const name of extract('<Icon name="mdi:home" /> <Icon name="mdi-light:home" />'))
+    expect(name.split(':')[1]).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+})


### PR DESCRIPTION
### 🔗 Linked issue

Related to #410, though it does not close it. See the last paragraph.

### 📚 Description

`createMatchRegex` wraps the match in `\b` (`src/core/scan.ts:82`). A `-` is a word boundary, so `\b` puts no constraint at all on a hyphenated identifier, and any one of them that happens to contain a collection prefix is read as an icon usage:

```
import 'source-map-js'              ->  map:js
undici-vs-builtin-fetch.md          ->  vs:builtin-fetch
<div style="--gg-size: 4px" />      ->  gg:size
```

The name part is `[a-z0-9-]+`, which also allows a leading or trailing `-`. `Fast-memory-efficient-Levenshtein` extracts `memory:efficient-`: the trailing `-` survives because the uppercase `L` closes the word boundary. That is not a name Iconify can ever accept, so it can only ever be thrown away later.

47 of the 220 built-in prefixes are three characters or shorter and 24 are two (`bi`, `ci`, `fa`, `gg`, `ix`, `la`, `ls`, `map`, `mi`, `ph`, `ri`, `si`, `vs`, ...), which is why this happens as often as it does rather than being a curiosity.

The fix asks for two things the old pattern did not: the match may not start or end inside a longer identifier, and the name has to follow [Iconify's own icon name grammar](https://github.com/iconify/iconify/blob/2274c033b49c01a50dc89b490b89d803d19d95dc/packages/utils/src/icon/name.ts#L15-L18) rather than "any run of lowercase, digits and dashes".

I deliberately did not go further and require the `i-` prefix for the dash form, which would have taken out `bi-monthly-report` and `data-test="mdi-check"` too. `stringToIcon('mdi-home')` resolves to `{ prefix: 'mdi', name: 'home' }`, so a bare `mdi-home` is a real usage, and `playgrounds/nuxt/app.vue:17` writes exactly that (`'logos-nuxt-icon'`). There is no way to tell those apart from prose by pattern alone, so they stay in.

### Test

I measured this before and after over the 5739 `.vue/.md/.mdc/.mdx/.yml/.yaml` files under this repo's `node_modules` (about 42 MB), using the scanner's own default `globInclude`:

```
current:   69 names extracted
candidate: 50 names extracted
removed (19): ci:href, ci:src, foundation:as-an-incubation-project, ix:ltd, map:0,
  map:buffer, map:from-entries, map:index-generator, map:js, map:key,
  map:label-fg-color, map:options, map:support, memory:efficient-,
  token:code-point, vs:bash, vs:builtin-fetch, vs:type-arguments,
  vs:unicode-scalar-values
added (0):
```

Every one of the 19 comes from prose or an identifier, and nothing new is picked up. The playground client bundle is byte-identical before and after, still `27 icons with 18.40KB`, and the existing `extract icon usages` snapshot is unchanged.

The three tests added to `test/extract.test.ts` cover the forms that must keep working (`mdi:home`, `mdi-home`, `i-mdi-home`, `i-mdi:home`, `dark:i-mdi-home`, `mdi-light:home`, `uil:0-plus`, `logos-nuxt-icon`), the identifier cases, and the grammar. Reverting `src/core/scan.ts` and keeping the tests fails the last two on the extraction itself:

```
FAIL  test/extract.test.ts > does not extract from the middle of a longer identifier
AssertionError: expected [ 'map:js' ] to deeply equal []

FAIL  test/extract.test.ts > never extracts a name that Iconify could not accept
AssertionError: expected [ 'memory:efficient-' ] to deeply equal []
```

`pnpm test:unit` is 27 passed, lint, `vue-tsc` and `pnpm build` are clean. `pnpm test:playground` fails on the committed `fixtures.html` snapshot both before and after, on a `solar` icon body that no longer matches, which looks like dependency drift and is unrelated to this.

### On #410

I could not make this account for what #410 describes. The reporter sees roughly 8000 icons; 42 MB of real files produce 69 extracted names here, and a scanned name whose collection is not installed locally never reaches the bundle anyway, because `markUnresolved` (`src/core/bundle.ts:130-143`) keeps scanned icons best-effort by design. So this is a smaller, separate correctness problem in the same code, not that report. Happy to open it as its own issue if you would rather have the link the other way round.


On the red CI here: it is the `mount fixtures` snapshot, and `main` fails the same way at dc20973 (`chore: release v2.5.1`), before this branch existed. The only thing in the diff is the `solar` icon body, so it is not from this change.