### PR TITLE
fix: don't append custom collection prefixes to the shared collection list

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -26,10 +26,12 @@ export class NuxtIconModuleContext {
   public scanner: IconUsageScanner | undefined
 
   getRuntimeCollections(runtimeOptions: NuxtIconRuntimeOptions): string[] {
+    // Copy: the custom prefixes below are appended in place, and `collectionNames`
+    // is a module-level constant shared with every other consumer in the process
     const resolved = runtimeOptions.fallbackToApi
-      ? collectionNames
+      ? [...collectionNames]
       : typeof this.options.serverBundle === 'string'
-        ? collectionNames
+        ? [...collectionNames]
         : this.options.serverBundle
           ? this.options.serverBundle.collections
             ?.map(c => typeof c === 'string' ? c : c.prefix) || []

--- a/test/runtime-collections.test.ts
+++ b/test/runtime-collections.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from 'vitest'
+import type { Nuxt } from '@nuxt/schema'
+import type { IconifyJSON } from '@iconify/types'
+import { NuxtIconModuleContext } from '../src/context'
+import type { ModuleOptions, NuxtIconRuntimeOptions } from '../src/types'
+import { collectionNames } from '../src/collection-names'
+
+function createContext(options: Partial<ModuleOptions>) {
+  const nuxt = {
+    options: {
+      rootDir: '/root',
+      nitro: {},
+      dev: false,
+    },
+  }
+  return new NuxtIconModuleContext(nuxt as unknown as Nuxt, options as ModuleOptions)
+}
+
+// `module.ts` only reads `fallbackToApi` out of the runtime options here
+const runtimeOptions = { fallbackToApi: true } as NuxtIconRuntimeOptions
+
+const customCollection: IconifyJSON = {
+  prefix: 'my-icons',
+  icons: {
+    logo: { body: '<path d="M0 0h24v24H0z"/>' },
+  },
+}
+
+it('keeps custom collection prefixes out of the shared Iconify collection list', () => {
+  const ctx = createContext({ customCollections: [customCollection] })
+  expect(ctx.getRuntimeCollections(runtimeOptions)).toContain('my-icons')
+
+  // Another app built in the same process must not inherit the first one's prefixes
+  const other = createContext({})
+  expect(other.getRuntimeCollections(runtimeOptions)).not.toContain('my-icons')
+  expect(collectionNames).not.toContain('my-icons')
+})
+
+it('does not add a remote endpoint for a custom collection', async () => {
+  const ctx = createContext({
+    provider: 'server',
+    serverBundle: 'remote',
+    customCollections: [customCollection],
+  })
+  // `module.ts` fills `appConfig.icon.collections` from this before the server bundle resolves
+  ctx.getRuntimeCollections(runtimeOptions)
+
+  const { collections } = await ctx.resolveServerBundle()
+  const entries = collections.filter(c => (typeof c === 'string' ? c : c.prefix) === 'my-icons')
+  expect(entries).toEqual([customCollection])
+})


### PR DESCRIPTION
### 📚 Description

`getRuntimeCollections` (`src/context.ts:28-45`) does not return a list, it returns the shared one and then writes to it:

```ts
const resolved = runtimeOptions.fallbackToApi
  ? collectionNames                 // <- the module-level constant itself
  : typeof this.options.serverBundle === 'string'
    ? collectionNames               // <- same
    : this.options.serverBundle
      ? this.options.serverBundle.collections?.map(...) || []   // <- fresh array
      : []

for (const collection of this.options.customCollections || []) {
  if (collection.prefix && !resolved.includes(collection.prefix))
    resolved.push(collection.prefix)
}
```

Three branches, and only the third builds its own array. The other two hand back `collectionNames` from `src/collection-names.ts`, which is generated, module-level, and read by `IconUsageScanner` (`src/core/scan.ts:21`), `discoverInstalledCollections` (`src/core/collections.ts:133-161`), `_resolveServerBundle` (`src/context.ts:104`), and by anyone importing it from `@nuxt/icon/utils`. The push appends every custom collection prefix to it permanently.

`fallbackToApi` defaults to `true`, so the default configuration takes a leaking branch, and `module.ts:110` calls this on every setup.

Two consequences:

**Across apps in one process.** Building or preparing two Nuxt apps in the same Node process (a test suite, a monorepo script, a programmatic `build()` loop) leaks the first app's custom prefixes into the second's `appConfig.icon.collections`. That list is what `useResolvedName` uses to disambiguate a dashed name, so app B starts resolving `my-icons-logo` to `my-icons:logo` for a collection it does not have.

**Inside a single build.** `module.ts:110` runs during `setup`, and `_resolveServerBundle` runs later from the `nitro:config` hook. With `serverBundle: 'remote'` (or `'auto'` on an edge preset) the second one reads the already-polluted `collectionNames`, so a custom collection is emitted twice in `nuxt-icon-server-bundle.mjs`: once as `createRemoteCollection('https://cdn.jsdelivr.net/npm/@iconify-json/my-icons/icons.json')` for a package that does not exist, and once as the real inline data.

The fix copies the list in the two branches that return the shared one. The `.map()` branch already produced a fresh array, so appending is now local in all three.

### Test

`test/runtime-collections.test.ts` covers both consequences, using the same fake-`Nuxt` style as `test/client-bundle.test.ts`. Both fail without the source change, each on the leaked value rather than on an error:

```
AssertionError: expected [ 'academicons', 'akar-icons', ...(219) ] to not include 'my-icons'
 ❯ test/runtime-collections.test.ts:35:59

AssertionError: expected [ 'my-icons', ...(1) ] to deeply equal [ { prefix: 'my-icons', ...(1) } ]
 ❯ test/runtime-collections.test.ts:50:19
```

I reverted `src/context.ts` to its committed state to confirm that, then restored it. `pnpm test:unit` is 29 passed, `pnpm lint` and `pnpm typecheck` are clean.
