### PR TITLE
fix(bundle): include custom collection aliases in the client bundle

### DIFF
--- a/src/core/bundle.ts
+++ b/src/core/bundle.ts
@@ -171,7 +171,9 @@ export async function resolveBundleIcons(options: ResolveBundleIconsOptions): Pr
 
   if (includeCustomCollections && customCollections.length) {
     for (const collection of customCollections) {
-      for (const name of Object.keys(collection.icons)) {
+      // An alias is a name users can render, so it belongs in the bundle too
+      const names = [...Object.keys(collection.icons), ...Object.keys(collection.aliases || {})]
+      for (const name of names) {
         const data = getIconData(collection, name)
         if (data) {
           addIcon(collection.prefix, name, data)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -116,6 +116,34 @@ it('bundles whole custom collections when includeCustomCollections is set', asyn
   expect(result.collections.find(c => c.prefix === 'custom')?.icons.baz).toBeTruthy()
 })
 
+it('bundles the aliases of a custom collection', async () => {
+  // The server bundle serves aliases (it ships the whole collection JSON), and
+  // an explicitly requested alias resolves here too, so the whole-collection
+  // path must not be the only one that drops them.
+  const result = await resolveBundleIcons({
+    customCollections: [{
+      prefix: 'custom-aliases',
+      icons: {
+        home: { body: '<path d="M0 0h24v24H0z"/>' },
+      },
+      aliases: {
+        'house': { parent: 'home' },
+        'home-flip': { parent: 'home', hFlip: true },
+      },
+      width: 24,
+      height: 24,
+    }],
+    includeCustomCollections: true,
+    resolvePaths: [root],
+  })
+
+  const collection = result.collections.find(c => c.prefix === 'custom-aliases')
+  expect(Object.keys(collection?.icons || {})).toEqual(['home', 'home-flip', 'house'])
+  expect(collection?.icons.house?.body).toBe('<path d="M0 0h24v24H0z"/>')
+  expect(collection?.icons['home-flip']?.hFlip).toBe(true)
+  expect(result.count).toBe(3)
+})
+
 it('resolves icons from custom collections before installed packages', async () => {
   // `@iconify-json/test-conflict` is installed with a different `baz` body
   // (see `beforeAll`), so this proves the custom collection takes precedence


### PR DESCRIPTION
### Bug

An alias declared in a custom `IconifyJSON` collection is missing from the client bundle when `clientBundle.includeCustomCollections` is on (its default when `provider` is not `server`). Rendering `<Icon name="paid-icons:house" />` then falls back to runtime loading, and with `provider: 'none'` it never renders at all.

### Reproduction

```ts
// nuxt.config.ts
export default defineNuxtConfig({
  modules: ['@nuxt/icon'],
  icon: {
    provider: 'none',
    customCollections: [
      {
        prefix: 'paid-icons',
        icons: { home: { body: '<path d="M0 0h24v24H0z"/>' } },
        aliases: { house: { parent: 'home' } },
        width: 24,
        height: 24,
      },
    ],
  },
})
```

`.nuxt/nuxt-icon-client-bundle.mjs` contains `paid-icons:home` but not `paid-icons:house`.

### Root cause

`resolveBundleIcons` walks only `Object.keys(collection.icons)` when bundling a whole custom collection, and an `IconifyJSON` keeps aliases in a separate `aliases` map. The two sibling paths already handle them: the server bundle serializes the entire collection JSON and `getIcons` resolves the alias at request time, and an alias listed explicitly in `clientBundle.icons` goes through `getIconData`, which follows the alias tree. Only the whole-collection path skipped them.

The fix walks `collection.aliases` as well and resolves each name through the same `getIconData` call, so an alias lands in the bundle as a normal icon with its parent body and its own transforms.

### Test

`test/bundle.test.ts` gains `bundles the aliases of a custom collection`: a collection with one icon and two aliases (a plain one and an `hFlip` one) must produce all three names, the alias must carry the parent body, and the flipped alias must keep `hFlip: true`. Without the change it fails with `expected [ 'home' ] to deeply equal [ 'home', 'home-flip', 'house' ]`.
